### PR TITLE
Add Python dataclasses for QuickMUD structs

### DIFF
--- a/mud/models/__init__.py
+++ b/mud/models/__init__.py
@@ -1,0 +1,27 @@
+"""Data models for QuickMUD translated from C structs."""
+
+from .area import Area
+from .room import Room, ExtraDescr, Exit, Reset
+from .mob import MobIndex, MobProgram
+from .obj import ObjIndex, ObjectData, Affect
+from .character import Character, PCData
+from .constants import Direction, Sector, Position, WearLocation
+
+__all__ = [
+    "Area",
+    "Room",
+    "ExtraDescr",
+    "Exit",
+    "Reset",
+    "MobIndex",
+    "MobProgram",
+    "ObjIndex",
+    "ObjectData",
+    "Affect",
+    "Character",
+    "PCData",
+    "Direction",
+    "Sector",
+    "Position",
+    "WearLocation",
+]

--- a/mud/models/area.py
+++ b/mud/models/area.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class Area:
+    """Python representation of AREA_DATA from merc.h"""
+    file_name: Optional[str] = None
+    name: Optional[str] = None
+    credits: Optional[str] = None
+    age: int = 0
+    nplayer: int = 0
+    low_range: int = 0
+    high_range: int = 0
+    min_vnum: int = 0
+    max_vnum: int = 0
+    empty: bool = False
+    builders: Optional[str] = None
+    vnum: int = 0
+    area_flags: int = 0
+    security: int = 0
+    helps: List[object] = field(default_factory=list)
+    next: Optional['Area'] = None

--- a/mud/models/character.py
+++ b/mud/models/character.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class PCData:
+    """Subset of PC_DATA from merc.h"""
+    pwd: Optional[str] = None
+    bamfin: Optional[str] = None
+    bamfout: Optional[str] = None
+    title: Optional[str] = None
+    perm_hit: int = 0
+    perm_mana: int = 0
+    perm_move: int = 0
+    true_sex: int = 0
+    last_level: int = 0
+    condition: List[int] = field(default_factory=lambda: [0] * 4)
+    points: int = 0
+    security: int = 0
+
+@dataclass
+class Character:
+    """Python representation of CHAR_DATA"""
+    name: Optional[str] = None
+    short_descr: Optional[str] = None
+    long_descr: Optional[str] = None
+    description: Optional[str] = None
+    prompt: Optional[str] = None
+    prefix: Optional[str] = None
+    sex: int = 0
+    ch_class: int = 0
+    race: int = 0
+    level: int = 0
+    trust: int = 0
+    hit: int = 0
+    max_hit: int = 0
+    mana: int = 0
+    max_mana: int = 0
+    move: int = 0
+    max_move: int = 0
+    gold: int = 0
+    silver: int = 0
+    exp: int = 0
+    act: int = 0
+    affected_by: int = 0
+    position: int = 0
+    practice: int = 0
+    train: int = 0
+    carry_weight: int = 0
+    carry_number: int = 0
+    saving_throw: int = 0
+    alignment: int = 0
+    hitroll: int = 0
+    damroll: int = 0
+    wimpy: int = 0
+    perm_stat: List[int] = field(default_factory=list)
+    mod_stat: List[int] = field(default_factory=list)
+    form: int = 0
+    parts: int = 0
+    size: int = 0
+    material: Optional[str] = None
+    off_flags: int = 0
+    damage: List[int] = field(default_factory=lambda: [0, 0, 0])
+    dam_type: int = 0
+    start_pos: int = 0
+    default_pos: int = 0
+    mprog_delay: int = 0
+    pcdata: Optional[PCData] = None

--- a/mud/models/constants.py
+++ b/mud/models/constants.py
@@ -1,0 +1,60 @@
+from enum import IntEnum
+
+class Direction(IntEnum):
+    """Mapping of direction constants from merc.h"""
+    NORTH = 0
+    EAST = 1
+    SOUTH = 2
+    WEST = 3
+    UP = 4
+    DOWN = 5
+
+class Sector(IntEnum):
+    """Sector types from merc.h"""
+    INSIDE = 0
+    CITY = 1
+    FIELD = 2
+    FOREST = 3
+    HILLS = 4
+    MOUNTAIN = 5
+    WATER_SWIM = 6
+    WATER_NOSWIM = 7
+    UNUSED = 8
+    AIR = 9
+    DESERT = 10
+    MAX = 11
+
+class Position(IntEnum):
+    """Character positions from merc.h"""
+    DEAD = 0
+    MORTAL = 1
+    INCAP = 2
+    STUNNED = 3
+    SLEEPING = 4
+    RESTING = 5
+    SITTING = 6
+    FIGHTING = 7
+    STANDING = 8
+
+class WearLocation(IntEnum):
+    """Equipment wear locations from merc.h"""
+    NONE = -1
+    LIGHT = 0
+    FINGER_L = 1
+    FINGER_R = 2
+    NECK_1 = 3
+    NECK_2 = 4
+    BODY = 5
+    HEAD = 6
+    LEGS = 7
+    FEET = 8
+    HANDS = 9
+    ARMS = 10
+    SHIELD = 11
+    ABOUT = 12
+    WAIST = 13
+    WRIST_L = 14
+    WRIST_R = 15
+    WIELD = 16
+    HOLD = 17
+    FLOAT = 18

--- a/mud/models/mob.py
+++ b/mud/models/mob.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+@dataclass
+class MobProgram:
+    """Representation of MPROG_LIST"""
+    trig_type: int
+    trig_phrase: Optional[str] = None
+    vnum: int = 0
+    code: Optional[str] = None
+
+@dataclass
+class MobIndex:
+    """Python representation of MOB_INDEX_DATA"""
+    vnum: int
+    player_name: Optional[str] = None
+    short_descr: Optional[str] = None
+    long_descr: Optional[str] = None
+    description: Optional[str] = None
+    spec_fun: Optional[str] = None
+    pShop: Optional[object] = None
+    mprogs: List[MobProgram] = field(default_factory=list)
+    area: Optional['Area'] = None
+    group: int = 0
+    new_format: bool = False
+    count: int = 0
+    killed: int = 0
+    act: int = 0
+    affected_by: int = 0
+    alignment: int = 0
+    level: int = 0
+    hitroll: int = 0
+    hit: Tuple[int, int, int] = (0, 0, 0)
+    mana: Tuple[int, int, int] = (0, 0, 0)
+    damage: Tuple[int, int, int] = (0, 0, 0)
+    ac: Tuple[int, int, int, int] = (0, 0, 0, 0)
+    dam_type: int = 0
+    off_flags: int = 0
+    imm_flags: int = 0
+    res_flags: int = 0
+    vuln_flags: int = 0
+    start_pos: int = 0
+    default_pos: int = 0
+    sex: int = 0
+    race: int = 0
+    wealth: int = 0
+    form: int = 0
+    parts: int = 0
+    size: int = 0
+    material: Optional[str] = None
+    mprog_flags: int = 0

--- a/mud/models/obj.py
+++ b/mud/models/obj.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from .room import ExtraDescr, Room
+from .character import Character
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class Affect:
+    """Representation of AFFECT_DATA"""
+    where: int
+    type: int
+    level: int
+    duration: int
+    location: int
+    modifier: int
+    bitvector: int
+
+@dataclass
+class ObjIndex:
+    """Python representation of OBJ_INDEX_DATA"""
+    vnum: int
+    name: Optional[str] = None
+    short_descr: Optional[str] = None
+    description: Optional[str] = None
+    material: Optional[str] = None
+    item_type: int = 0
+    extra_flags: int = 0
+    wear_flags: int = 0
+    level: int = 0
+    condition: int = 0
+    count: int = 0
+    weight: int = 0
+    cost: int = 0
+    value: List[int] = field(default_factory=lambda: [0] * 5)
+    affected: List[Affect] = field(default_factory=list)
+    extra_descr: List['ExtraDescr'] = field(default_factory=list)
+    area: Optional['Area'] = None
+    new_format: bool = False
+    reset_num: int = 0
+    next: Optional['ObjIndex'] = None
+
+@dataclass
+class ObjectData:
+    """Python representation of OBJ_DATA"""
+    item_type: int
+    extra_flags: int = 0
+    wear_flags: int = 0
+    wear_loc: int = 0
+    weight: int = 0
+    cost: int = 0
+    level: int = 0
+    condition: int = 0
+    timer: int = 0
+    value: List[int] = field(default_factory=lambda: [0] * 5)
+    owner: Optional[str] = None
+    name: Optional[str] = None
+    short_descr: Optional[str] = None
+    description: Optional[str] = None
+    material: Optional[str] = None
+    carried_by: Optional['Character'] = None
+    in_obj: Optional['ObjectData'] = None
+    contains: List['ObjectData'] = field(default_factory=list)
+    extra_descr: List['ExtraDescr'] = field(default_factory=list)
+    affected: List[Affect] = field(default_factory=list)
+    pIndexData: Optional[ObjIndex] = None
+    in_room: Optional['Room'] = None
+    enchanted: bool = False
+    next_content: Optional['ObjectData'] = None
+    next: Optional['ObjectData'] = None

--- a/mud/models/room.py
+++ b/mud/models/room.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .constants import Direction
+
+@dataclass
+class ExtraDescr:
+    """Python representation of EXTRA_DESCR_DATA"""
+    keyword: Optional[str] = None
+    description: Optional[str] = None
+
+@dataclass
+class Exit:
+    """Representation of EXIT_DATA"""
+    to_room: Optional['Room'] = None
+    vnum: Optional[int] = None
+    exit_info: int = 0
+    key: int = 0
+    keyword: Optional[str] = None
+    description: Optional[str] = None
+    rs_flags: int = 0
+    orig_door: int = 0
+
+@dataclass
+class Reset:
+    """Representation of RESET_DATA"""
+    command: str
+    arg1: int
+    arg2: int
+    arg3: int
+    arg4: int
+
+@dataclass
+class Room:
+    """Python representation of ROOM_INDEX_DATA"""
+    vnum: int
+    name: Optional[str] = None
+    description: Optional[str] = None
+    owner: Optional[str] = None
+    area: Optional['Area'] = None
+    room_flags: int = 0
+    light: int = 0
+    sector_type: int = 0
+    heal_rate: int = 0
+    mana_rate: int = 0
+    clan: int = 0
+    exits: List[Optional[Exit]] = field(default_factory=lambda: [None] * len(Direction))
+    extra_descr: List[ExtraDescr] = field(default_factory=list)
+    resets: List[Reset] = field(default_factory=list)
+    people: List['Character'] = field(default_factory=list)
+    contents: List['ObjectData'] = field(default_factory=list)
+    next: Optional['Room'] = None


### PR DESCRIPTION
## Summary
- add initial Python data models mirroring core QuickMUD C structs
- provide enums for common constants such as directions, sectors and wear slots

## Testing
- `python3 -m py_compile mud/models/*.py`

------
https://chatgpt.com/codex/tasks/task_b_6858482a87348320a9a5139fb534870a