### PR TITLE
Implement inventory persistence

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1236,9 +1236,9 @@ def create_test_account():
 
 ### 🛠️ Next Step
 
-- Step 10 will support inventory persistence and loadable equipment, followed by automated account creation or authentication.
+- [x] Step 10: Add Inventory and Equipment Persistence
 
-## 🎒 Step 10: Add Inventory and Equipment Persistence
+## ✅ Step 10: Add Inventory and Equipment Persistence
 
 **Objective**: Enable characters to carry and equip objects that persist in the database. Inventory and equipment should be loaded at login and saved at logout.
 

--- a/mud/account/account_manager.py
+++ b/mud/account/account_manager.py
@@ -5,12 +5,15 @@ from typing import Optional
 from mud.db.session import SessionLocal
 from mud.db.models import Character as DBCharacter
 from mud.models.character import Character, from_orm
+from mud.models.conversion import load_objects_for_character, save_objects_for_character
 
 
 def load_character(username: str, char_name: str) -> Optional[Character]:
     session = SessionLocal()
     db_char = session.query(DBCharacter).filter_by(name=char_name).first()
     char = from_orm(db_char) if db_char else None
+    if char:
+        char.inventory, char.equipment = load_objects_for_character(db_char)
     session.close()
     return char
 
@@ -23,5 +26,6 @@ def save_character(character: Character) -> None:
         db_char.hp = character.hit
         if getattr(character, "room", None):
             db_char.room_vnum = character.room.vnum
+        save_objects_for_character(session, character, db_char)
         session.commit()
     session.close()

--- a/mud/db/models.py
+++ b/mud/db/models.py
@@ -57,6 +57,17 @@ class ObjPrototype(Base):
     value3 = Column(Integer)
 
 
+class ObjectInstance(Base):
+    __tablename__ = "object_instances"
+    id = Column(Integer, primary_key=True)
+    prototype_vnum = Column(Integer, ForeignKey("obj_prototypes.vnum"))
+    location = Column(String)
+    character_id = Column(Integer, ForeignKey("characters.id"))
+
+    prototype = relationship("ObjPrototype")
+    character = relationship("Character", back_populates="objects")
+
+
 class PlayerAccount(Base):
     __tablename__ = "player_accounts"
     id = Column(Integer, primary_key=True)
@@ -76,4 +87,5 @@ class Character(Base):
 
     player_id = Column(Integer, ForeignKey("player_accounts.id"))
     player = relationship("PlayerAccount", back_populates="characters")
+    objects = relationship("ObjectInstance", back_populates="character")
 

--- a/mud/models/__init__.py
+++ b/mud/models/__init__.py
@@ -4,6 +4,7 @@ from .area import Area
 from .room import Room, ExtraDescr, Exit, Reset
 from .mob import MobIndex, MobProgram
 from .obj import ObjIndex, ObjectData, Affect
+from .object import Object
 from .character import Character, PCData
 from .constants import (
     Direction,
@@ -25,6 +26,7 @@ __all__ = [
     "MobProgram",
     "ObjIndex",
     "ObjectData",
+    "Object",
     "Affect",
     "Character",
     "PCData",

--- a/mud/models/character.py
+++ b/mud/models/character.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from mud.spawning.templates import ObjectInstance
+    from mud.models.object import Object
     from mud.db.models import Character as DBCharacter
 
 @dataclass
@@ -70,19 +70,21 @@ class Character:
     default_pos: int = 0
     mprog_delay: int = 0
     pcdata: Optional[PCData] = None
-    inventory: List['ObjectInstance'] = field(default_factory=list)
+    inventory: List['Object'] = field(default_factory=list)
+    equipment: Dict[str, 'Object'] = field(default_factory=dict)
     messages: List[str] = field(default_factory=list)
     connection: Optional[object] = None
 
     def __repr__(self) -> str:
         return f"<Character name={self.name!r} level={self.level}>"
 
-    def add_object(self, obj: 'ObjectInstance') -> None:
+    def add_object(self, obj: 'Object') -> None:
         self.inventory.append(obj)
-        obj.location = None
 
-    def equip_object(self, obj: 'ObjectInstance', slot: int) -> None:
-        self.add_object(obj)
+    def equip_object(self, obj: 'Object', slot: str) -> None:
+        if obj in self.inventory:
+            self.inventory.remove(obj)
+        self.equipment[slot] = obj
 
 
 character_registry: list[Character] = []

--- a/mud/models/object.py
+++ b/mud/models/object.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .room import Room
+
+from .obj import ObjIndex
+
+
+@dataclass
+class Object:
+    """Instance of an object tied to a prototype."""
+    instance_id: Optional[int]
+    prototype: ObjIndex
+    location: Optional['Room'] = None
+    contained_items: List['Object'] = field(default_factory=list)
+
+    @property
+    def name(self) -> Optional[str]:
+        return self.prototype.name
+
+    @property
+    def short_descr(self) -> Optional[str]:
+        return getattr(self.prototype, "short_descr", None)

--- a/mud/models/room.py
+++ b/mud/models/room.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass, field
 from typing import List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from mud.spawning.templates import ObjectInstance, MobInstance
+    from mud.models.object import Object
+    from mud.spawning.templates import MobInstance
 
 from .constants import Direction
 
@@ -52,7 +53,7 @@ class Room:
     extra_descr: List[ExtraDescr] = field(default_factory=list)
     resets: List[Reset] = field(default_factory=list)
     people: List['Character'] = field(default_factory=list)
-    contents: List['ObjectData'] = field(default_factory=list)
+    contents: List['Object'] = field(default_factory=list)
     next: Optional['Room'] = None
 
     def __repr__(self) -> str:
@@ -67,10 +68,11 @@ class Room:
         if char in self.people:
             self.people.remove(char)
 
-    def add_object(self, obj: 'ObjectInstance') -> None:
+    def add_object(self, obj: 'Object') -> None:
         if obj not in self.contents:
             self.contents.append(obj)
-        obj.location = self
+        if hasattr(obj, "location"):
+            obj.location = self
 
     def add_mob(self, mob: 'MobInstance') -> None:
         if mob not in self.people:

--- a/mud/spawning/obj_spawner.py
+++ b/mud/spawning/obj_spawner.py
@@ -2,17 +2,11 @@ from __future__ import annotations
 from typing import Optional
 
 from mud.registry import obj_registry
-from .templates import ObjectInstance
+from mud.models.object import Object
 
 
-def spawn_object(vnum: int) -> Optional[ObjectInstance]:
+def spawn_object(vnum: int) -> Optional[Object]:
     proto = obj_registry.get(vnum)
     if not proto:
         return None
-    obj = ObjectInstance(
-        name=proto.name,
-        short_descr=proto.short_descr,
-        item_type=proto.item_type,
-        prototype=proto,
-    )
-    return obj
+    return Object(instance_id=None, prototype=proto)

--- a/mud/spawning/templates.py
+++ b/mud/spawning/templates.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from mud.models.object import Object
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mud.models.mob import MobIndex
     from mud.models.obj import ObjIndex
+    from mud.models.object import Object
 
 
 @dataclass
@@ -34,7 +37,7 @@ class MobInstance:
     level: int
     current_hp: int
     prototype: MobIndex
-    inventory: List[ObjectInstance] = field(default_factory=list)
+    inventory: List[Object] = field(default_factory=list)
     room: Optional['Room'] = None
 
     @classmethod
@@ -50,9 +53,8 @@ class MobInstance:
         room.people.append(self)
         self.room = room
 
-    def add_to_inventory(self, obj: ObjectInstance) -> None:
+    def add_to_inventory(self, obj: Object) -> None:
         self.inventory.append(obj)
-        obj.location = None
 
-    def equip(self, obj: ObjectInstance, slot: int) -> None:  # stub
+    def equip(self, obj: Object, slot: int) -> None:  # stub
         self.add_to_inventory(obj)

--- a/tests/test_inventory_persistence.py
+++ b/tests/test_inventory_persistence.py
@@ -1,0 +1,35 @@
+from mud.world import initialize_world, create_test_character
+from mud.spawning.obj_spawner import spawn_object
+from mud.account.account_manager import save_character, load_character
+from mud.db.models import Base, PlayerAccount
+from mud.db.session import engine, SessionLocal
+from mud.models.character import to_orm
+
+
+def test_inventory_and_equipment_persistence(tmp_path):
+    # use fresh in-memory sqlite database
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    initialize_world('area/area.lst')
+
+    char = create_test_character('Tester', 3001)
+    session = SessionLocal()
+    account = PlayerAccount(username='tester', password_hash='x')
+    session.add(account)
+    session.commit()
+    db_char = to_orm(char, account.id)
+    session.add(db_char)
+    session.commit()
+    session.close()
+    sword = spawn_object(3022)
+    helmet = spawn_object(3356)
+    assert sword and helmet
+    char.add_object(sword)
+    char.equip_object(helmet, 'head')
+
+    save_character(char)
+
+    loaded = load_character(char.name, char.name)
+    assert loaded is not None
+    assert any(obj.prototype.vnum == 3022 for obj in loaded.inventory)
+    assert loaded.equipment['head'].prototype.vnum == 3356


### PR DESCRIPTION
## Summary
- add `ObjectInstance` DB model and relationships
- support save/load of objects from DB
- create `Object` dataclass for runtime items
- update spawners and world models to use new objects
- test inventory and equipment persistence
- mark Step 10 done in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868621f3358832093020cb1edbe825c