### PR TITLE
Implement Step 11 - account login and creation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1395,7 +1395,7 @@ session.commit()
 
 - Step 11 will implement **account creation, character selection**, and password authentication to allow proper user onboarding.
 
-## 🔐 Step 11: Account Creation and Authentication
+## ✅ Step 11: Account Creation and Authentication
 
 **Objective**: Allow users to create accounts with secure passwords, authenticate at login, and manage multiple characters under one account. This replaces manual test-account creation and enables real-world usage.
 
@@ -1415,7 +1415,7 @@ session.commit()
 
 ### ✅ Tasks and Subtasks
 
-#### 1. Add Utility Functions for Hashing and Checking Passwords
+#### 1. Add Utility Functions for Hashing and Checking Passwords ✅
 
 **1.1 In `mud/security/hash_utils.py`:**
 
@@ -1437,7 +1437,7 @@ def verify_password(password: str, stored_hash: str) -> bool:
 
 ---
 
-#### 2. Add Account Creation Flow
+#### 2. Add Account Creation Flow ✅
 
 **2.1 In `mud/account/account_service.py`:**
 
@@ -1461,7 +1461,7 @@ def create_account(username: str, raw_password: str) -> bool:
 
 ---
 
-#### 3. Add Login Flow
+#### 3. Add Login Flow ✅
 
 ```python
 def login(username: str, raw_password: str) -> Optional[PlayerAccount]:
@@ -1474,7 +1474,7 @@ def login(username: str, raw_password: str) -> Optional[PlayerAccount]:
 
 ---
 
-#### 4. Character Selection and Creation
+#### 4. Character Selection and Creation ✅
 
 ```python
 def list_characters(account: PlayerAccount) -> List[str]:
@@ -1492,7 +1492,7 @@ def create_character(account: PlayerAccount, name: str, starting_room_vnum: int 
 
 ---
 
-#### 5. Add a Temporary CLI Login Menu (for testing)
+#### 5. Add a Temporary CLI Login Menu (for testing) ✅
 
 **5.1 In `mud/entrypoint.py` or similar:**
 

--- a/mud/account/__init__.py
+++ b/mud/account/__init__.py
@@ -1,5 +1,18 @@
-# Account management utilities
+"""Account management utilities."""
 
 from .account_manager import load_character, save_character
+from .account_service import (
+    create_account,
+    login,
+    list_characters,
+    create_character,
+)
 
-__all__ = ["load_character", "save_character"]
+__all__ = [
+    "load_character",
+    "save_character",
+    "create_account",
+    "login",
+    "list_characters",
+    "create_character",
+]

--- a/mud/account/account_service.py
+++ b/mud/account/account_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Optional, List
+
+from mud.db.session import SessionLocal
+from mud.db.models import PlayerAccount, Character
+from mud.security.hash_utils import hash_password, verify_password
+
+
+def create_account(username: str, raw_password: str) -> bool:
+    """Create a new PlayerAccount if username is available."""
+    session = SessionLocal()
+    if session.query(PlayerAccount).filter_by(username=username).first():
+        session.close()
+        return False
+    account = PlayerAccount(
+        username=username,
+        password_hash=hash_password(raw_password),
+    )
+    session.add(account)
+    session.commit()
+    session.close()
+    return True
+
+
+def login(username: str, raw_password: str) -> Optional[PlayerAccount]:
+    """Return PlayerAccount if credentials match."""
+    session = SessionLocal()
+    account = session.query(PlayerAccount).filter_by(username=username).first()
+    if account and verify_password(raw_password, account.password_hash):
+        # pre-load characters before detaching
+        account.characters  # type: ignore[unused-any]
+        session.expunge(account)
+        session.close()
+        return account
+    session.close()
+    return None
+
+
+def list_characters(account: PlayerAccount) -> List[str]:
+    """Return list of character names for this account."""
+    return [char.name for char in getattr(account, "characters", [])]
+
+
+def create_character(
+    account: PlayerAccount, name: str, starting_room_vnum: int = 3001
+) -> bool:
+    """Create a new character for the account."""
+    session = SessionLocal()
+    if session.query(Character).filter_by(name=name).first():
+        session.close()
+        return False
+    new_char = Character(
+        name=name,
+        level=1,
+        hp=100,
+        room_vnum=starting_room_vnum,
+        player_id=account.id,
+    )
+    session.add(new_char)
+    session.commit()
+    session.close()
+    return True

--- a/mud/entrypoint.py
+++ b/mud/entrypoint.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from mud.account.account_service import create_account, login
+
+
+def prompt_login():
+    print("Welcome to the Realm.")
+    username = input("Username: ")
+    password = input("Password: ")
+
+    account = login(username, password)
+    if not account:
+        print("❌ Invalid login.")
+        return None
+
+    print(f"✅ Logged in as {username}")
+    return account
+
+
+def prompt_account_creation():
+    print("Create your account:")
+    username = input("Username: ")
+    password = input("Password: ")
+    confirm = input("Confirm Password: ")
+    if password != confirm:
+        print("❌ Passwords do not match.")
+        return None
+
+    success = create_account(username, password)
+    if success:
+        print("✅ Account created.")
+    else:
+        print("❌ Username already taken.")
+    return success

--- a/mud/security/hash_utils.py
+++ b/mud/security/hash_utils.py
@@ -1,0 +1,20 @@
+import hashlib
+import os
+
+
+def hash_password(password: str) -> str:
+    """Return a salted hash for the given password."""
+    salt = os.urandom(16)
+    hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100_000)
+    return salt.hex() + ":" + hashed.hex()
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """Check password against the stored ``salt:hash`` string."""
+    try:
+        salt_hex, hash_hex = stored_hash.split(":")
+    except ValueError:
+        return False
+    salt = bytes.fromhex(salt_hex)
+    new_hash = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100_000)
+    return new_hash.hex() == hash_hex

--- a/tests/test_account_auth.py
+++ b/tests/test_account_auth.py
@@ -1,0 +1,35 @@
+from mud.db.models import Base, PlayerAccount, Character
+from mud.db.session import engine, SessionLocal
+from mud.account.account_service import (
+    create_account,
+    login,
+    create_character,
+    list_characters,
+)
+from mud.security.hash_utils import verify_password
+
+
+def setup_module(module):
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+
+
+def test_account_create_and_login():
+    assert create_account("alice", "secret")
+    assert not create_account("alice", "other")
+
+    account = login("alice", "secret")
+    assert account is not None
+    assert login("alice", "bad") is None
+
+    # check hash format
+    session = SessionLocal()
+    db_acc = session.query(PlayerAccount).filter_by(username="alice").first()
+    assert db_acc and ":" in db_acc.password_hash
+    assert verify_password("secret", db_acc.password_hash)
+    session.close()
+
+    assert create_character(account, "Hero")
+    account = login("alice", "secret")
+    chars = list_characters(account)
+    assert "Hero" in chars


### PR DESCRIPTION
## Summary
- implement secure password hashing utilities
- add account service with create/login/list functions
- provide CLI login prompts for manual testing
- expose new account helpers from package
- add unit test covering account auth flow
- mark Step 11 complete in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68686d8bdb3c8320be029af3c87a7585