### PR TITLE
Implement admin command system

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1548,9 +1548,9 @@ def prompt_account_creation():
 
 ### 🛠️ Next Step
 
-- Step 12 will introduce **admin tools**, debugging commands (`@who`, `@teleport`, `@spawn`), and in-game state inspection for live world testing.
+- ✔ Step 12 will introduce **admin tools**, debugging commands (`@who`, `@teleport`, `@spawn`), and in-game state inspection for live world testing.
 
-## 🛠️ Step 12: Admin Tools and Debug Commands
+## ✅ Step 12: Admin Tools and Debug Commands
 
 **Objective**: Add a set of privileged commands for admins to inspect world state, test gameplay, and moderate the game live. These commands are not player-accessible and should respect access levels or account flags.
 

--- a/mud/account/account_manager.py
+++ b/mud/account/account_manager.py
@@ -12,7 +12,8 @@ def load_character(username: str, char_name: str) -> Optional[Character]:
     session = SessionLocal()
     db_char = session.query(DBCharacter).filter_by(name=char_name).first()
     char = from_orm(db_char) if db_char else None
-    if char:
+    if char and db_char:
+        db_char.player  # load relationship
         char.inventory, char.equipment = load_objects_for_character(db_char)
     session.close()
     return char

--- a/mud/commands/admin_commands.py
+++ b/mud/commands/admin_commands.py
@@ -1,0 +1,39 @@
+from mud.models.character import Character
+from mud.registry import room_registry
+from mud.spawning.mob_spawner import spawn_mob
+from mud.net.session import SESSIONS
+from mud.commands.decorators import admin_only
+
+
+@admin_only
+def cmd_who(char: Character, args: str) -> str:
+    lines = ["Online Players:"]
+    for sess in SESSIONS.values():
+        c = sess.character
+        room_vnum = c.room.vnum if getattr(c, "room", None) else "?"
+        lines.append(f" - {c.name} in room {room_vnum}")
+    return "\n".join(lines)
+
+
+@admin_only
+def cmd_teleport(char: Character, args: str) -> str:
+    if not args.isdigit() or int(args) not in room_registry:
+        return "Invalid room."
+    target = room_registry[int(args)]
+    if char.room:
+        char.room.remove_character(char)
+    target.add_character(char)
+    return f"Teleported to room {args}"
+
+
+@admin_only
+def cmd_spawn(char: Character, args: str) -> str:
+    if not args.isdigit():
+        return "Invalid vnum."
+    mob = spawn_mob(int(args))
+    if not mob:
+        return "NPC not found."
+    if not char.room:
+        return "Nowhere to spawn."
+    char.room.add_mob(mob)
+    return f"Spawned {mob.name}."

--- a/mud/commands/decorators.py
+++ b/mud/commands/decorators.py
@@ -1,0 +1,11 @@
+from functools import wraps
+from mud.models.character import Character
+
+
+def admin_only(func):
+    @wraps(func)
+    def wrapper(char: Character, *args, **kwargs):
+        if not getattr(char, "is_admin", False):
+            return "You do not have permission to use this command."
+        return func(char, *args, **kwargs)
+    return wrapper

--- a/mud/commands/dispatcher.py
+++ b/mud/commands/dispatcher.py
@@ -6,6 +6,7 @@ from .movement import do_north, do_south, do_east, do_west, do_up, do_down
 from .inspection import do_look
 from .inventory import do_get, do_drop, do_inventory
 from .communication import do_say
+from .admin_commands import cmd_who, cmd_teleport, cmd_spawn
 
 CommandFunc = Callable[[Character, str], str]
 
@@ -21,6 +22,9 @@ COMMANDS: Dict[str, CommandFunc] = {
     "drop": do_drop,
     "inventory": do_inventory,
     "say": do_say,
+    "@who": cmd_who,
+    "@teleport": cmd_teleport,
+    "@spawn": cmd_spawn,
 }
 
 

--- a/mud/db/models.py
+++ b/mud/db/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, Boolean
 from sqlalchemy.orm import relationship, declarative_base
 
 Base = declarative_base()
@@ -73,6 +73,7 @@ class PlayerAccount(Base):
     id = Column(Integer, primary_key=True)
     username = Column(String, unique=True)
     password_hash = Column(String)
+    is_admin = Column(Boolean, default=False)
 
     characters = relationship("Character", back_populates="player")
 

--- a/mud/db/seed.py
+++ b/mud/db/seed.py
@@ -14,6 +14,7 @@ def create_test_account():
     account = PlayerAccount(
         username="admin",
         password_hash=hashlib.sha256(b"admin").hexdigest(),
+        is_admin=True,
     )
     char = Character(name="Testman", level=1, hp=100, room_vnum=3001, player=account)
     session.add(account)

--- a/mud/models/character.py
+++ b/mud/models/character.py
@@ -74,6 +74,7 @@ class Character:
     equipment: Dict[str, 'Object'] = field(default_factory=dict)
     messages: List[str] = field(default_factory=list)
     connection: Optional[object] = None
+    is_admin: bool = False
 
     def __repr__(self) -> str:
         return f"<Character name={self.name!r} level={self.level}>"
@@ -100,6 +101,8 @@ def from_orm(db_char: 'DBCharacter') -> Character:
         hit=db_char.hp or 0,
     )
     char.room = room
+    if db_char.player is not None:
+        char.is_admin = bool(getattr(db_char.player, "is_admin", False))
     return char
 
 

--- a/mud/net/session.py
+++ b/mud/net/session.py
@@ -15,3 +15,7 @@ class Session:
 
 
 SESSIONS: Dict[str, Session] = {}
+
+
+def get_online_players() -> list[Character]:
+    return [sess.character for sess in SESSIONS.values()]

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1,0 +1,36 @@
+from mud.world import initialize_world, create_test_character
+from mud.commands import process_command
+from mud.net.session import Session, SESSIONS
+
+
+def setup_module(module):
+    initialize_world('area/area.lst')
+
+
+def teardown_function(function):
+    SESSIONS.clear()
+
+
+def test_admin_commands_permissions():
+    admin = create_test_character('Admin', 3001)
+    admin.is_admin = True
+    sess_admin = Session(name='Admin', character=admin, reader=None, writer=None)
+    SESSIONS['Admin'] = sess_admin
+
+    player = create_test_character('Bob', 3001)
+    sess_player = Session(name='Bob', character=player, reader=None, writer=None)
+    SESSIONS['Bob'] = sess_player
+
+    out_admin = process_command(admin, '@who')
+    assert 'Admin' in out_admin and 'Bob' in out_admin
+
+    out_player = process_command(player, '@who')
+    assert 'permission' in out_player.lower()
+
+    out_tp = process_command(admin, '@teleport 3005')
+    assert 'Teleported' in out_tp
+    assert admin.room.vnum == 3005
+
+    out_spawn = process_command(admin, '@spawn 3000')
+    assert 'Spawned' in out_spawn
+    assert any(mob.prototype.vnum == 3000 for mob in admin.room.people if hasattr(mob, 'prototype'))


### PR DESCRIPTION
## Summary
- add `is_admin` to `PlayerAccount`
- support admin flag when loading characters
- add admin-only command decorator
- implement `@who`, `@teleport`, and `@spawn` commands
- expose online sessions in `get_online_players`
- test admin command permissions
- mark Step 12 complete in TODO

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68689308cc98832093a73879dab5f3e4