### PR TITLE
Fix container startup with volume mount for Poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3.11-slim
 
-WORKDIR /app
+WORKDIR /app/mud
 
 COPY mud/pyproject.toml ./pyproject.toml
-RUN pip install poetry && poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
+RUN pip install poetry && poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi
 
-COPY . .
+COPY . /app
 
-CMD ["mud", "runserver"]
+CMD ["poetry", "run", "mud", "socketserver"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       - .env
     volumes:
       - .:/app
-    command: poetry run mud socketserver
+      - ./mud/pyproject.toml:/app/mud/pyproject.toml


### PR DESCRIPTION
## Summary
- ensure pyproject is available when container uses bind mounts
- update Dockerfile to run from `/app/mud` with Poetry
- mount `mud/pyproject.toml` explicitly in docker-compose

## Testing
- `poetry install --no-interaction`
- `poetry run pytest ../tests` *(fails: FileNotFoundError: 'area/area.lst')*

------
https://chatgpt.com/codex/tasks/task_b_6878758809c88320a1ea68ef593216fa