### PR TITLE
Fix poetry config and Docker install path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM python:3.11-slim
 
-WORKDIR /app/mud
+WORKDIR /app
 
-COPY mud/pyproject.toml ./pyproject.toml
-RUN pip install poetry && poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi
+COPY mud/pyproject.toml mud/poetry.lock ./mud/
+RUN pip install --no-cache-dir poetry \
+    && poetry -C mud config virtualenvs.create false \
+    && poetry -C mud install --no-interaction --no-ansi
 
 COPY . /app
 
-CMD ["poetry", "run", "mud", "socketserver"]
+CMD ["poetry", "-C", "mud", "run", "mud", "socketserver"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       - .env
     volumes:
       - .:/app
-      - ./mud/pyproject.toml:/app/mud/pyproject.toml
+      # Mount source code for live reload during development

--- a/mud/pyproject.toml
+++ b/mud/pyproject.toml
@@ -3,7 +3,7 @@ name = "quickmud"
 version = "0.1.0"
 description = "QuickMUD Python tools"
 authors = ["QuickMUD Team <example@example.com>"]
-package-mode = false
+packages = [{ include = "mud" }]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
## Summary
- point poetry to the `mud` package so entrypoints work
- adjust Dockerfile to install from the project directory
- simplify docker-compose volume mapping

## Testing
- `poetry -C mud run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68787c3508f48320b326ee6de1bb6ea1