### PR TITLE
Improve Dockerfile for missing poetry.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 FROM python:3.11-slim
 
-WORKDIR /app/mud
+WORKDIR /app
 
-COPY mud/pyproject.toml ./pyproject.toml
-RUN pip install poetry && poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi
+# Copy project metadata first for better layer caching
+COPY mud/pyproject.toml /app/mud/pyproject.toml
 
+# Copy the mud package including a lock file if present
+COPY mud/ /app/mud/
+
+# Install Poetry and project dependencies. If no lock file is
+# present, generate one during the build.
+RUN pip install --no-cache-dir poetry \
+    && if [ ! -f /app/mud/poetry.lock ]; then \
+         poetry -C /app/mud lock; \
+       fi \
+    && poetry -C /app/mud install --no-interaction --no-ansi
+
+# Copy the rest of the repository
 COPY . /app
 
 CMD ["poetry", "run", "mud", "socketserver"]


### PR DESCRIPTION
## Summary
- handle missing `poetry.lock` during Docker build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68787dedbdf483208e74822ccc596595