### PR TITLE
Fix setup script generation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ COPY . .
 # package directory, so use a lightweight setup.py for installation.
 RUN printf "from setuptools import setup, find_packages\n"\
           "packages=['mud']+[f'mud.{p}' for p in find_packages('mud')]\n"\
-          "setup(name='quickmud', version='0.1.0', packages=packages, \"\
-package_dir={'mud':'mud'}, entry_points={'console_scripts':['mud=mud.__main__:cli']})\n" \
+          "setup(name='quickmud', version='0.1.0', packages=packages, package_dir={'mud':'mud'}, entry_points={'console_scripts':['mud=mud.__main__:cli']})\n" \
     > setup.py \
     && pip install -e . \
     && rm setup.py


### PR DESCRIPTION
## Summary
- fix quoting in Dockerfile's temporary setup.py script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687d99b6604483209431054aaf31f16a