### PR TITLE
Fix Docker build by adding setup.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,8 @@ COPY . .
 
 # Install the quickmud package itself so the "mud" entry point is available.
 # Poetry cannot discover the package because the project name differs from the
-# package directory, so use a lightweight setup.py for installation.
-RUN printf "from setuptools import setup, find_packages\n"\
-          "packages=['mud']+[f'mud.{p}' for p in find_packages('mud')]\n"\
-          "setup(name='quickmud', version='0.1.0', packages=packages, \"\
-package_dir={'mud':'mud'}, entry_points={'console_scripts':['mud=mud.__main__:cli']})\n" \
-    > setup.py \
-    && pip install -e . \
-    && rm setup.py
+# package directory, so we provide our own setup.py.
+COPY setup.py ./
+RUN pip install -e .
 
 CMD ["mud", "socketserver"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='quickmud',
+    version='0.1.0',
+    packages=['mud'] + [f'mud.{p}' for p in find_packages('mud')],
+    package_dir={'mud': 'mud'},
+    entry_points={
+        'console_scripts': [
+            'mud=mud.__main__:cli',
+        ],
+    },
+)


### PR DESCRIPTION
## Summary
- add a real `setup.py` to package quickmud
- copy `setup.py` in the Dockerfile instead of generating one
- clarify Dockerfile comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d9b74f6348320bce5a22308baaf6e