### PR TITLE
Fix quickmud package installation in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info
+player/
+log/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ RUN pip install --no-cache-dir poetry
 COPY mud/pyproject.toml mud/pyproject.toml
 RUN poetry -C mud install --no-interaction --no-ansi --no-root
 
-# Copy the rest of the repository
-COPY . .
-
-# Install the quickmud package itself so the "mud" entry point is available.
-# Poetry cannot discover the package because the project name differs from the
-# package directory, so we provide our own setup.py.
+# Copy only the source and setup script first so the package installs
+# correctly even when the build context is not the repository root.
 COPY setup.py ./
-RUN pip install -e .
+COPY mud/ mud/
+RUN pip install .
+
+# Copy the rest of the repository (areas, docs, etc.).
+COPY . .
 
 CMD ["mud", "socketserver"]


### PR DESCRIPTION
## Summary
- copy quickmud sources and setup script before install
- install package in non-editable mode so entry point works with volume mounts
- add a .dockerignore to trim build context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d9f8a789c8320a731c83ad30ee616