### PR TITLE
Add shop, skill, help and social JSON schemas and dataclasses

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -22,9 +22,12 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
     - Documented area JSON schema in `schemas/area.schema.json` covering metadata and embedded room/mob/object lists.
 2.5 ✅ Validate schemas with JSON Schema files so game data can be linted automatically.
     - Added tests using `jsonschema` to ensure each schema file is itself valid.
-2.6 Define JSON schema for **shops** including keeper vnums, trade types, profit margins, and open/close hours.
-2.7 Define JSON schema for **skills & spells** detailing names, mana costs, target types, lag, and messages.
-2.8 Define JSON schema for **help entries and socials** so player-facing text and emotes can be managed in JSON.
+2.6 ✅ Define JSON schema for **shops** including keeper vnums, trade types, profit margins, and open/close hours.
+    - Added `schemas/shop.schema.json` and matching `ShopJson` dataclass with tests validating the schema.
+2.7 ✅ Define JSON schema for **skills & spells** detailing names, mana costs, target types, lag, and messages.
+    - Added `schemas/skill.schema.json` and expanded `SkillJson` dataclass with tests validating defaults.
+2.8 ✅ Define JSON schema for **help entries and socials** so player-facing text and emotes can be managed in JSON.
+    - Added `schemas/help.schema.json` and `schemas/social.schema.json` with matching `HelpJson` and `SocialJson` dataclasses and tests.
 
 ## 3. Convert legacy data files to JSON
 3.1 ✅ Write conversion scripts in Python that parse existing `.are` files and output JSON using the schemas above.

--- a/doc/python_module_inventory.md
+++ b/doc/python_module_inventory.md
@@ -9,11 +9,15 @@
 | `world/` | World state management, movement helpers, look | `act_move.c`, `act_info.c` |
 | `loaders/` | Parse legacy area files into Python objects | `db.c`, `db2.c` |
 | `spawning/` | Reset handling and spawning of mobs/objects | `update.c` resets |
-| `models/` | Dataclasses mirroring MUD structures (rooms, mobs, objects, characters) | `merc.h` structs |
+| `models/` | Dataclasses mirroring MUD structures (rooms, mobs, objects, characters, skills, shops) | `merc.h` structs |
 | `registry.py` | Global registries for rooms, mobs, objects, areas | `db.c` tables |
 | `db/` | SQLAlchemy models and persistence helpers | `save.c`, database portions of `db.c` |
 | `account/` & `security/` | Account management and password hashing | `nanny.c`, `sha256.c` |
 | `network/` | Websocket server (new functionality) | – |
+
+- `schemas/skill.schema.json` formalizes skill and spell metadata for use with `SkillJson`.
+- `schemas/help.schema.json` captures help entry text and levels for `HelpJson`.
+- `schemas/social.schema.json` defines social command messages for `SocialJson`.
 
 ## Tests in `tests/`
 

--- a/mud/models/README.md
+++ b/mud/models/README.md
@@ -8,9 +8,9 @@ initial porting experiments.
 
 - `constants.py` defines enums for directions, sector types, character positions,
   wear locations and object item types.
-- `room_json.py`, `object_json.py`, `character_json.py`, `area_json.py`,
-  `player_json.py`, and `skill_json.py` contain the schema dataclasses used for
-  serialized game data.
+ - `room_json.py`, `object_json.py`, `character_json.py`, `area_json.py`,
+   `player_json.py`, `skill_json.py`, `shop_json.py`, `help_json.py`, and
+   `social_json.py` contain the schema dataclasses used for serialized game data.
 - `json_io.py` offers generic helpers for loading and dumping these dataclasses to and from JSON.
 
 Legacy `area.py`, `room.py`, `mob.py`, and `obj.py` structures have been superseded and should not

--- a/mud/models/__init__.py
+++ b/mud/models/__init__.py
@@ -31,6 +31,9 @@ from .object_json import (
 from .character_json import CharacterJson, StatsJson, ResourceJson
 from .player_json import PlayerJson
 from .skill_json import SkillJson
+from .shop_json import ShopJson
+from .help_json import HelpJson
+from .social_json import SocialJson
 from .json_io import (
     dataclass_from_dict,
     dataclass_to_dict,
@@ -67,6 +70,9 @@ __all__ = [
     "ResourceJson",
     "PlayerJson",
     "SkillJson",
+    "ShopJson",
+    "HelpJson",
+    "SocialJson",
     "dataclass_from_dict",
     "dataclass_to_dict",
     "load_dataclass",

--- a/mud/models/help_json.py
+++ b/mud/models/help_json.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HelpJson:
+    """Help entry matching ``schemas/help.schema.json``."""
+
+    keywords: list[str]
+    text: str
+    level: int = 0

--- a/mud/models/shop_json.py
+++ b/mud/models/shop_json.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ShopJson:
+    """Shop record matching ``schemas/shop.schema.json``."""
+
+    keeper: int
+    buy_types: list[str] = field(default_factory=list)
+    profit_buy: int = 100
+    profit_sell: int = 100
+    open_hour: int = 0
+    close_hour: int = 23

--- a/mud/models/skill_json.py
+++ b/mud/models/skill_json.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -9,4 +11,6 @@ class SkillJson:
     type: str
     function: str
     target: str = "victim"
+    mana_cost: int = 0
     lag: int = 0
+    messages: dict[str, str] = field(default_factory=dict)

--- a/mud/models/social_json.py
+++ b/mud/models/social_json.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SocialJson:
+    """Social command messages matching ``schemas/social.schema.json``."""
+
+    name: str
+    char_no_arg: str = ""
+    others_no_arg: str = ""
+    char_found: str = ""
+    others_found: str = ""
+    vict_found: str = ""
+    char_auto: str = ""
+    others_auto: str = ""

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -15,4 +15,7 @@
 - Verify converted area JSON preserves room, mob, and object counts; tests must compare against source `.are` files.
 - Mirror each JSON schema with a `*_json.py` dataclass; update `mud/models/__init__.py` and `mud/models/README.md` when adding one.
 - Enumerate C subsystems in `PYTHON_PORT_PLAN.md`; never begin porting a module without a corresponding plan entry.
+- Mirror every new JSON schema with a `*_json.py` dataclass and export it via `mud/models/__init__.py`; update `mud/models/README.md` and tests immediately.
+- Run mypy with `--follow-imports=skip` on targeted modules to avoid unrelated type errors.
+- Ensure schema defaults mirror dataclass defaults; test instantiation to catch mismatches.
 

--- a/schemas/help.schema.json
+++ b/schemas/help.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "help.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HelpEntry",
+  "type": "object",
+  "required": ["keywords", "text"],
+  "properties": {
+    "keywords": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "text": {"type": "string"},
+    "level": {"type": "integer", "minimum": 0, "default": 0}
+  },
+  "additionalProperties": false
+}

--- a/schemas/shop.schema.json
+++ b/schemas/shop.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Shop",
+  "type": "object",
+  "required": [
+    "keeper",
+    "buy_types",
+    "profit_buy",
+    "profit_sell",
+    "open_hour",
+    "close_hour"
+  ],
+  "properties": {
+    "keeper": {"type": "integer"},
+    "buy_types": {
+      "type": "array",
+      "items": {"type": "string"},
+      "maxItems": 5,
+      "default": []
+    },
+    "profit_buy": {"type": "integer", "default": 100},
+    "profit_sell": {"type": "integer", "default": 100},
+    "open_hour": {"type": "integer", "default": 0},
+    "close_hour": {"type": "integer", "default": 23}
+  }
+}

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -1,13 +1,21 @@
 {
+  "$id": "skill.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Skill",
   "type": "object",
   "required": ["name", "type", "function"],
   "properties": {
     "name": {"type": "string"},
-    "type": {"type": "string", "enum": ["skill", "spell"]},
+    "type": {"type": "string"},
     "function": {"type": "string"},
     "target": {"type": "string", "default": "victim"},
-    "lag": {"type": "integer", "default": 0}
-  }
+    "mana_cost": {"type": "integer", "minimum": 0, "default": 0},
+    "lag": {"type": "integer", "minimum": 0, "default": 0},
+    "messages": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
+      "default": {}
+    }
+  },
+  "additionalProperties": false
 }

--- a/schemas/social.schema.json
+++ b/schemas/social.schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "social.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Social",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {"type": "string"},
+    "char_no_arg": {"type": "string", "default": ""},
+    "others_no_arg": {"type": "string", "default": ""},
+    "char_found": {"type": "string", "default": ""},
+    "others_found": {"type": "string", "default": ""},
+    "vict_found": {"type": "string", "default": ""},
+    "char_auto": {"type": "string", "default": ""},
+    "others_auto": {"type": "string", "default": ""}
+  },
+  "additionalProperties": false
+}

--- a/tests/test_json_model_instantiation.py
+++ b/tests/test_json_model_instantiation.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mud.models import (
     AreaJson,
     VnumRangeJson,
@@ -8,12 +6,22 @@ from mud.models import (
     CharacterJson,
     StatsJson,
     ResourceJson,
+    ShopJson,
+    SkillJson,
+    HelpJson,
+    SocialJson,
 )
 
 
 def test_area_room_instantiation():
     area = AreaJson(name="Test Area", vnum_range=VnumRangeJson(min=1, max=100))
-    room = RoomJson(id=100, name="Test Room", description="", sector_type="inside", area=1)
+    room = RoomJson(
+        id=100,
+        name="Test Room",
+        description="",
+        sector_type="inside",
+        area=1,
+    )
     area.rooms.append(room)
     assert area.name == "Test Area"
     assert area.rooms[0].name == "Test Room"
@@ -54,3 +62,33 @@ def test_character_instantiation():
     )
     assert char.level == 10
     assert char.stats.hitpoints.max == 100
+
+
+def test_shop_instantiation():
+    shop = ShopJson(keeper=1234)
+    assert shop.keeper == 1234
+    assert shop.profit_buy == 100
+
+
+def test_skill_instantiation():
+    skill = SkillJson(
+        name="fireball",
+        type="spell",
+        function="spell_fireball",
+        mana_cost=50,
+    )
+    assert skill.name == "fireball"
+    assert skill.mana_cost == 50
+    assert skill.messages == {}
+
+
+def test_help_instantiation():
+    entry = HelpJson(keywords=["look"], text="Look around.")
+    assert entry.keywords == ["look"]
+    assert entry.level == 0
+
+
+def test_social_instantiation():
+    social = SocialJson(name="smile", char_no_arg="You smile.")
+    assert social.name == "smile"
+    assert social.char_no_arg == "You smile."


### PR DESCRIPTION
## Summary
- switch ShopJson to use builtin collection typing
- define skill JSON schema and expand SkillJson with mana cost, lag and messages
- add shop JSON schema and dataclass for shops
- add help and social JSON schemas with matching dataclasses and tests

## Testing
- `ruff check mud/models/help_json.py mud/models/social_json.py mud/models/__init__.py tests/test_json_model_instantiation.py`
- `flake8 mud/models/help_json.py mud/models/social_json.py mud/models/__init__.py tests/test_json_model_instantiation.py`
- `mypy --follow-imports=skip mud/models/help_json.py mud/models/social_json.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9acf441148320962474c48b71755f