### PR TITLE
Implement atomic JSON persistence for players

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -45,38 +45,32 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
 ## 4. Implement Python data models
 4.1 ✅ Create `dataclasses` in `mud/models/` mirroring the JSON schemas.
     - Added `PlayerJson` dataclass and documented it alongside existing schema models.
-4.2 Add serialization/deserialization helpers to read/write JSON and handle default values.
-    - Provide `to_dict`/`from_dict` helpers for each dataclass.
-    - Validate required fields and apply schema defaults on load.
-    - Write round-trip tests proving data integrity.
-4.3 Replace legacy models referencing `merc.h` structures with these new dataclasses.
-    - Identify every module that includes `merc.h` and map it to a Python dataclass.
-    - Remove `merc.h` dependencies and update imports.
-    - Update cross-reference docs once C structs are dropped.
-4.4 Add dataclasses for shops, skills/spells, help entries, and socials mirroring the new schemas.
+4.2 ✅ Add serialization/deserialization helpers to read/write JSON and handle default values.
+    - Added `JsonDataclass` mixin supplying `to_dict`/`from_dict` and default handling.
+    - Round-trip tests ensure schema defaults are preserved for rooms and areas.
+4.3 ✅ Replace legacy models referencing `merc.h` structures with these new dataclasses.
+    - Identified modules cloning `RESET_DATA` and switched loaders/handlers to `ResetJson`.
+    - Removed direct `merc.h` dependencies and refreshed cross-reference docs.
+4.4 ✅ Add dataclasses for shops, skills/spells, help entries, and socials mirroring the new schemas.
+    - Introduced runtime `Shop`, `Skill`, `HelpEntry`, and `Social` models built from their JSON counterparts.
 
 ## 5. Replace C subsystems with Python equivalents
-5.1 **World loading & resets** – implement reset logic in Python to spawn mobs/objects per area definitions.
-    - Schedule resets, link exits, and honor area reset commands.
-    - Verify repopulation through unit tests.
-5.2 **Command interpreter** – expand existing dispatcher to cover all player commands currently implemented in C.
-    - Implement argument parsing, abbreviations, and permissions.
-    - Port movement, information, object, and wizard command sets.
-5.3 **Combat engine** – port attack rounds, damage calculations, and status effects; ensure turn‑based loop is replicated.
-    - Handle hit/miss rolls, position changes, and death cleanup.
-    - Integrate combat tests covering melee and spell damage.
-5.4 **Skills & spells** – create a registry of skill/spell functions in Python, reading definitions from JSON.
-    - Load skill/spell metadata from JSON and wire to effect handlers.
-    - Support cooldowns, mana costs, and failure rates.
-5.5 **Character advancement** – implement experience, leveling, and class/race modifiers.
-    - Port practice/train commands and progression tables.
-    - Write tests verifying level gains and stat increases.
-5.6 **Shops & economy** – port shop data, buying/selling logic, and currency handling.
-    - Convert shopkeepers and stock lists to JSON and dataclasses.
-    - Implement transactions, inventory refresh, and gold sinks.
-5.7 **Persistence** – replace C save files with JSON; implement load/save for players and world state.
-    - Ensure atomic file writes and crash-safe recovery.
-    - Migrate player equipment and inventory serialization.
+5.1 ✅ **World loading & resets** – implement reset logic in Python to spawn mobs/objects per area definitions.
+    - Added tick-based scheduler that clears rooms and reapplies resets, with tests confirming area repopulation.
+5.2 ✅ **Command interpreter** – expand existing dispatcher to cover all player commands currently implemented in C.
+    - Added prefix-based command resolution, quote-aware argument parsing, and admin permission gating.
+    - Tests cover abbreviations and quoted arguments across movement, information, object, and wizard commands.
+5.3 ✅ **Combat engine** – port attack rounds, damage calculations, and status effects; ensure turn‑based loop is replicated.
+    - Introduced hit/miss mechanics with position tracking and death removal, covered by new combat tests.
+5.4 ✅ **Skills & spells** – create a registry of skill/spell functions in Python, reading definitions from JSON.
+    - Skill registry loads definitions from JSON, enforces mana costs and cooldowns, applies failure rates, and dispatches to handlers.
+5.5 ✅ **Character advancement** – implement experience, leveling, and class/race modifiers.
+    - Added progression tables with level-based stat gains.
+    - Implemented practice/train commands and tests for level-up stat increases.
+5.6 ✅ **Shops & economy** – port shop data, buying/selling logic, and currency handling.
+    - Shop commands list, buy, and sell with profit margins and buy-type restrictions.
+5.7 ✅ **Persistence** – replace C save files with JSON; implement load/save for players and world state.
+    - Characters saved atomically to JSON with inventories and equipment; world loader restores them into rooms.
 5.8 **Networking** – use existing async telnet server; gradually remove any remaining C networking code.
     - Integrate login flow, prompt handling, and ANSI support.
     - Add tests for multiple simultaneous connections.

--- a/data/skills.json
+++ b/data/skills.json
@@ -1,3 +1,12 @@
 [
-  {"name": "fireball", "type": "spell", "function": "fireball"}
+  {
+    "name": "fireball",
+    "type": "spell",
+    "function": "fireball",
+    "target": "victim",
+    "mana_cost": 10,
+    "lag": 12,
+    "cooldown": 2,
+    "failure_rate": 0.0
+  }
 ]

--- a/doc/c_python_cross_reference.md
+++ b/doc/c_python_cross_reference.md
@@ -3,15 +3,16 @@
 | System | C Modules | Python Modules | Status |
 | --- | --- | --- | --- |
 | Networking loop | `comm.c` | `mud/net/`, `mud/server.py` | Python telnet server mirrors network loop; C loop still used in legacy engine |
-| Command interpreter & basic commands | `interp.c`, `act_move.c`, `act_obj.c`, `act_comm.c`, `act_wiz.c` | `mud/commands/` | Python dispatcher covers movement, communication, inventory, admin |
+| Command interpreter & basic commands | `interp.c`, `act_move.c`, `act_obj.c`, `act_comm.c`, `act_wiz.c` | `mud/commands/` | Python dispatcher covers movement, communication, inventory, admin; supports abbreviations & permission checks |
 | World loading | `db.c`, `db2.c` | `mud/loaders/`, `mud/registry.py` | Python loaders parse areas into world registry; C loader still serves legacy runtime |
-| Reset/spawning | `update.c` (resets) | `mud/spawning/` | Python spawning handles tests; C update loop still authoritative |
-| Data models | `merc.h` structs | `mud/models/` | Dataclasses mirror C structures but are not yet integrated |
-| Persistence | `save.c` | `mud/db/` | Python uses SQLAlchemy for accounts and inventories; C still saves characters |
+| Reset/spawning | `update.c` (resets) | `mud/spawning/` | Python scheduler clears and repopulates areas; C update loop unused in tests |
+| Data models | `merc.h` structs | `mud/models/` | Reset logic now uses schema dataclasses instead of `merc.h` structs; runtime dataclasses added for shops, skills, helps, socials |
+| Persistence | `save.c` | `mud/persistence.py`, `mud/db/` | Characters saved to JSON with atomic file replacement |
 | Accounts & security | `nanny.c`, `sha256.c` | `mud/account/`, `mud/security/` | Python handles account creation and hashing; login flow incomplete |
-| Combat engine | `fight.c` | – | Not yet ported |
-| Skills & spells | `skills.c`, `magic.c`, `magic2.c` | – | Not yet ported |
-| Shops & economy | `healer.c`, shop logic in other files | – | Not yet ported |
+| Combat engine | `fight.c` | `mud/combat/` | Python engine resolves hit/miss rolls and death cleanup |
+| Skills & spells | `skills.c`, `magic.c`, `magic2.c` | `mud/skills/` | JSON-driven registry dispatches skill handlers |
+| Character advancement | `update.c`, `act_info.c` | `mud/advancement.py`, `mud/commands/advancement.py` | Python handles experience, leveling, practice, and training |
+| Shops & economy | `healer.c`, shop logic in other files | `mud/commands/shop.py`, `mud/loaders/shop_loader.py` | Python lists, buys, and sells items using profit margins |
 | OLC / Builders | `olc.c`, `olc_act.c`, `olc_save.c`, `olc_mpcode.c` | – | Not yet ported |
 | Mob programs | `mob_prog.c`, `mob_cmds.c` | – | Not yet ported |
 | InterMUD | `imc.c` | – | Not yet ported |

--- a/doc/python_module_inventory.md
+++ b/doc/python_module_inventory.md
@@ -5,12 +5,16 @@
 | Module | Purpose | C Feature Equivalent |
 | --- | --- | --- |
 | `net/` & `server.py` | Async telnet server and connection handling | `comm.c` network loop |
-| `commands/` | Command dispatcher and basic commands (movement, inventory, communication, admin) | `interp.c`, `act_move.c`, `act_obj.c`, `act_comm.c`, `act_wiz.c` |
+| `commands/` | Command dispatcher and basic commands (movement, inventory, communication, admin, shops) | `interp.c`, `act_move.c`, `act_obj.c`, `act_comm.c`, `act_wiz.c`, shop code |
 | `world/` | World state management, movement helpers, look | `act_move.c`, `act_info.c` |
 | `loaders/` | Parse legacy area files into Python objects | `db.c`, `db2.c` |
 | `spawning/` | Reset handling and spawning of mobs/objects | `update.c` resets |
+| `combat/` | Basic melee resolution and combat helpers | `fight.c` |
+| `skills/` | Skill registry and spell handlers | `skills.c`, `magic.c` |
+| `advancement.py` | Experience gain, leveling, practice/train | `update.c`, `act_info.c` |
 | `models/` | Dataclasses mirroring MUD structures (rooms, mobs, objects, characters, skills, shops) | `merc.h` structs |
 | `registry.py` | Global registries for rooms, mobs, objects, areas | `db.c` tables |
+| `persistence.py` | JSON save/load for characters and world | `save.c` |
 | `db/` | SQLAlchemy models and persistence helpers | `save.c`, database portions of `db.c` |
 | `account/` & `security/` | Account management and password hashing | `nanny.c`, `sha256.c` |
 | `network/` | Websocket server (new functionality) | – |
@@ -35,3 +39,7 @@
 | `test_are_conversion.py` | `.are` to JSON conversion produces valid schema |
 | `test_schema_validation.py` | JSON schemas remain valid |
 | `test_area_counts.py` | Area JSON preserves room/mob/object counts |
+| `test_combat.py` | Basic melee hit/miss and death handling |
+| `test_skills.py` | Skill registry, mana costs, and failure rates |
+| `test_advancement.py` | Level gains, practice, and training |
+| `test_shops.py` | Shop listing and transactions |

--- a/mud/advancement.py
+++ b/mud/advancement.py
@@ -19,11 +19,32 @@ RACE_XP_MOD = {
     2: 0.9,  # dwarf
 }
 
+# Per-class stat gains applied on level-up: (hp, mana, move)
+LEVEL_BONUS = {
+    0: (8, 6, 4),  # mage
+    1: (6, 8, 4),  # cleric
+    2: (7, 6, 5),  # thief
+    3: (10, 4, 6),  # warrior
+}
+
+PRACTICES_PER_LEVEL = 2
+TRAINS_PER_LEVEL = 1
+
 def exp_per_level(char: Character) -> int:
     """Base experience required for a single level."""
     class_mod = CLASS_XP_MOD.get(char.ch_class, 1.0)
     race_mod = RACE_XP_MOD.get(char.race, 1.0)
     return int(BASE_XP_PER_LEVEL * class_mod * race_mod)
+
+
+def advance_level(char: Character) -> None:
+    """Increase hit points, mana, move, practices, and trains."""
+    hp, mana, move = LEVEL_BONUS.get(char.ch_class, (8, 6, 5))
+    char.max_hit += hp
+    char.max_mana += mana
+    char.max_move += move
+    char.practice += PRACTICES_PER_LEVEL
+    char.train += TRAINS_PER_LEVEL
 
 def gain_exp(char: Character, amount: int) -> None:
     """Grant experience and handle level ups.
@@ -37,4 +58,5 @@ def gain_exp(char: Character, amount: int) -> None:
     # Level up while total exp meets threshold for next level.
     while char.exp >= exp_per_level(char) * (char.level + 1):
         char.level += 1
+        advance_level(char)
 

--- a/mud/combat/engine.py
+++ b/mud/combat/engine.py
@@ -1,18 +1,34 @@
 from __future__ import annotations
 
+import random
+
 from mud.models.character import Character
+from mud.models.constants import Position
 
 
 def attack_round(attacker: Character, victim: Character) -> str:
     """Resolve a single attack round.
 
-    Damage is computed from the attacker's `damroll` and applied to the
-    victim's hit points.  If the victim dies, remove them from the room.
+    The attacker attempts to hit the victim.  Hit chance is derived from a
+    base 50% modified by the attacker's ``hitroll``.  Successful hits apply
+    ``damroll`` damage.  Living combatants are placed into FIGHTING position.
+    If the victim dies, they are removed from the room and their position set
+    to ``DEAD``.
     """
+
+    attacker.position = Position.FIGHTING
+    victim.position = Position.FIGHTING
+
+    to_hit = 50 + attacker.hitroll
+    if random.randint(1, 100) > to_hit:
+        return f"You miss {victim.name}."
+
     damage = max(1, attacker.damroll)
     victim.hit -= damage
     if victim.hit <= 0:
         victim.hit = 0
+        victim.position = Position.DEAD
+        attacker.position = Position.STANDING
         if getattr(victim, "room", None):
             victim.room.broadcast(f"{victim.name} is DEAD!!!", exclude=victim)
             victim.room.remove_character(victim)

--- a/mud/commands/admin_commands.py
+++ b/mud/commands/admin_commands.py
@@ -2,10 +2,8 @@ from mud.models.character import Character
 from mud.registry import room_registry
 from mud.spawning.mob_spawner import spawn_mob
 from mud.net.session import SESSIONS
-from mud.commands.decorators import admin_only
 
 
-@admin_only
 def cmd_who(char: Character, args: str) -> str:
     lines = ["Online Players:"]
     for sess in SESSIONS.values():
@@ -15,7 +13,6 @@ def cmd_who(char: Character, args: str) -> str:
     return "\n".join(lines)
 
 
-@admin_only
 def cmd_teleport(char: Character, args: str) -> str:
     if not args.isdigit() or int(args) not in room_registry:
         return "Invalid room."
@@ -26,7 +23,6 @@ def cmd_teleport(char: Character, args: str) -> str:
     return f"Teleported to room {args}"
 
 
-@admin_only
 def cmd_spawn(char: Character, args: str) -> str:
     if not args.isdigit():
         return "Invalid vnum."

--- a/mud/commands/advancement.py
+++ b/mud/commands/advancement.py
@@ -1,0 +1,36 @@
+from mud.models.character import Character
+from mud.skills.registry import skill_registry
+
+
+def do_practice(char: Character, args: str) -> str:
+    if not args:
+        return f"You have {char.practice} practice sessions left."
+    if char.practice <= 0:
+        return "You have no practice sessions left."
+    skill_name = args.lower()
+    if skill_name not in skill_registry.skills:
+        return "You can't practice that."
+    current = char.skills.get(skill_name, 0)
+    if current >= 75:
+        return f"You are already learned at {skill_name}."
+    char.practice -= 1
+    char.skills[skill_name] = min(current + 25, 75)
+    return f"You practice {skill_name}."
+
+
+def do_train(char: Character, args: str) -> str:
+    if not args:
+        return f"You have {char.train} training sessions left."
+    if char.train <= 0:
+        return "You have no training sessions left."
+    stat = args.lower()
+    if stat not in {"hp", "mana", "move"}:
+        return "Train what?"
+    if stat == "hp":
+        char.max_hit += 10
+    elif stat == "mana":
+        char.max_mana += 10
+    else:
+        char.max_move += 10
+    char.train -= 1
+    return f"You train your {stat}."

--- a/mud/commands/dispatcher.py
+++ b/mud/commands/dispatcher.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-from typing import Callable, Dict
+from dataclasses import dataclass
+import shlex
+from typing import Callable, Dict, List, Optional
 
 from mud.models.character import Character
 from .movement import do_north, do_south, do_east, do_west, do_up, do_down
@@ -8,43 +10,79 @@ from .inventory import do_get, do_drop, do_inventory, do_equipment
 from .communication import do_say
 from .combat import do_kill
 from .admin_commands import cmd_who, cmd_teleport, cmd_spawn
-from .shop import do_list, do_buy
+from .shop import do_list, do_buy, do_sell
+from .advancement import do_practice, do_train
 
 CommandFunc = Callable[[Character, str], str]
 
-COMMANDS: Dict[str, CommandFunc] = {
-    "look": do_look,
-    "north": do_north,
-    "south": do_south,
-    "east": do_east,
-    "west": do_west,
-    "up": do_up,
-    "down": do_down,
-    "get": do_get,
-    "drop": do_drop,
-    "inventory": do_inventory,
-    "equipment": do_equipment,
-    "say": do_say,
-    "kill": do_kill,
-    "attack": do_kill,
-    "list": do_list,
-    "buy": do_buy,
-    "@who": cmd_who,
-    "@teleport": cmd_teleport,
-    "@spawn": cmd_spawn,
-}
+
+@dataclass(frozen=True)
+class Command:
+    name: str
+    func: CommandFunc
+    aliases: tuple[str, ...] = ()
+    admin_only: bool = False
+
+
+COMMANDS: List[Command] = [
+    Command("look", do_look, aliases=("l",)),
+    Command("north", do_north, aliases=("n",)),
+    Command("south", do_south, aliases=("s",)),
+    Command("east", do_east, aliases=("e",)),
+    Command("west", do_west, aliases=("w",)),
+    Command("up", do_up, aliases=("u",)),
+    Command("down", do_down, aliases=("d",)),
+    Command("get", do_get, aliases=("g",)),
+    Command("drop", do_drop),
+    Command("inventory", do_inventory, aliases=("inv",)),
+    Command("equipment", do_equipment, aliases=("eq",)),
+    Command("say", do_say),
+    Command("kill", do_kill, aliases=("attack",)),
+    Command("list", do_list),
+    Command("buy", do_buy),
+    Command("sell", do_sell),
+    Command("practice", do_practice),
+    Command("train", do_train),
+    Command("@who", cmd_who, admin_only=True),
+    Command("@teleport", cmd_teleport, admin_only=True),
+    Command("@spawn", cmd_spawn, admin_only=True),
+]
+
+
+COMMAND_INDEX: Dict[str, Command] = {}
+for cmd in COMMANDS:
+    COMMAND_INDEX[cmd.name] = cmd
+    for alias in cmd.aliases:
+        COMMAND_INDEX[alias] = cmd
+
+
+def resolve_command(name: str) -> Optional[Command]:
+    name = name.lower()
+    if name in COMMAND_INDEX:
+        return COMMAND_INDEX[name]
+    matches = [cmd for cmd in COMMANDS if cmd.name.startswith(name)]
+    if len(matches) == 1:
+        return matches[0]
+    return None
 
 
 def process_command(char: Character, input_str: str) -> str:
     if not input_str.strip():
         return "What?"
-    cmd, *rest = input_str.strip().split(maxsplit=1)
-    cmd = cmd.lower()
-    args = rest[0] if rest else ""
-    func = COMMANDS.get(cmd)
-    if not func:
+    try:
+        parts = shlex.split(input_str)
+    except ValueError:
         return "Huh?"
-    return func(char, args)
+    if not parts:
+        return "What?"
+    cmd_name, *args = parts
+    command = resolve_command(cmd_name)
+    if not command:
+        return "Huh?"
+    if command.admin_only and not getattr(char, "is_admin", False):
+        return "You do not have permission to use this command."
+    arg_str = " ".join(args)
+    return command.func(char, arg_str)
 
 
 def run_test_session() -> list[str]:

--- a/mud/commands/shop.py
+++ b/mud/commands/shop.py
@@ -1,5 +1,7 @@
-from mud.models.character import Character
+"""Shop command handlers."""
+
 from mud.registry import shop_registry
+from mud.models.character import Character
 
 
 def _find_shopkeeper(char: Character):
@@ -10,17 +12,28 @@ def _find_shopkeeper(char: Character):
     return None
 
 
+def _get_shop(keeper):
+    proto = getattr(keeper, "prototype", None)
+    if proto:
+        return shop_registry.get(proto.vnum)
+    return None
+
+
 def do_list(char: Character, args: str = "") -> str:
     keeper = _find_shopkeeper(char)
     if not keeper:
+        return "You can't do that here."
+    shop = _get_shop(keeper)
+    if not shop:
         return "You can't do that here."
     if not keeper.inventory:
         return "The shop is out of stock."
     items = []
     for obj in keeper.inventory:
         name = obj.short_descr or obj.name or "item"
-        cost = getattr(obj.prototype, "cost", 0)
-        items.append(f"{name} {cost} gold")
+        base_cost = getattr(obj.prototype, "cost", 0)
+        price = base_cost * shop.profit_buy // 100
+        items.append(f"{name} {price} gold")
     return "Items for sale: " + ", ".join(items)
 
 
@@ -30,15 +43,45 @@ def do_buy(char: Character, args: str) -> str:
     keeper = _find_shopkeeper(char)
     if not keeper:
         return "You can't do that here."
+    shop = _get_shop(keeper)
+    if not shop:
+        return "You can't do that here."
     name = args.lower()
     for obj in list(keeper.inventory):
         obj_name = (obj.short_descr or obj.name or "").lower()
         if name in obj_name:
-            cost = getattr(obj.prototype, "cost", 0)
-            if char.gold < cost:
+            base_cost = getattr(obj.prototype, "cost", 0)
+            price = base_cost * shop.profit_buy // 100
+            if char.gold < price:
                 return "You can't afford that."
-            char.gold -= cost
+            char.gold -= price
             keeper.inventory.remove(obj)
             char.add_object(obj)
-            return f"You buy {obj.short_descr or obj.name} for {cost} gold."
+            return f"You buy {obj.short_descr or obj.name} for {price} gold."
     return "The shopkeeper doesn't sell that."
+
+
+def do_sell(char: Character, args: str) -> str:
+    if not args:
+        return "Sell what?"
+    keeper = _find_shopkeeper(char)
+    if not keeper:
+        return "You can't do that here."
+    shop = _get_shop(keeper)
+    if not shop:
+        return "You can't do that here."
+    name = args.lower()
+    for obj in list(char.inventory):
+        obj_name = (obj.short_descr or obj.name or "").lower()
+        if name in obj_name:
+            item_type = getattr(obj.prototype, "item_type", 0)
+            if shop.buy_types and item_type not in shop.buy_types:
+                return "The shopkeeper doesn't buy that."
+            base_cost = getattr(obj.prototype, "cost", 0)
+            price = base_cost * shop.profit_sell // 100
+            char.gold += price
+            char.inventory.remove(obj)
+            keeper.inventory.append(obj)
+            return f"You sell {obj.short_descr or obj.name} for {price} gold."
+    return "You don't have that."
+

--- a/mud/loaders/reset_loader.py
+++ b/mud/loaders/reset_loader.py
@@ -1,5 +1,5 @@
-from mud.models.room import Reset
 from .base_loader import BaseTokenizer
+from mud.models.room_json import ResetJson
 
 
 def load_resets(tokenizer: BaseTokenizer, area):
@@ -25,5 +25,5 @@ def load_resets(tokenizer: BaseTokenizer, area):
         # pad to four integers
         while len(nums) < 4:
             nums.append(0)
-        reset = Reset(command=cmd, arg1=nums[0], arg2=nums[1], arg3=nums[2], arg4=nums[3])
+        reset = ResetJson(command=cmd, arg1=nums[0], arg2=nums[1], arg3=nums[2], arg4=nums[3])
         area.resets.append(reset)

--- a/mud/models/README.md
+++ b/mud/models/README.md
@@ -8,10 +8,14 @@ initial porting experiments.
 
 - `constants.py` defines enums for directions, sector types, character positions,
   wear locations and object item types.
- - `room_json.py`, `object_json.py`, `character_json.py`, `area_json.py`,
-   `player_json.py`, `skill_json.py`, `shop_json.py`, `help_json.py`, and
-   `social_json.py` contain the schema dataclasses used for serialized game data.
+- `room_json.py`, `object_json.py`, `character_json.py`, `area_json.py`,
+  `player_json.py`, `skill_json.py`, `shop_json.py`, `help_json.py`, and
+  `social_json.py` contain the schema dataclasses used for serialized game data.
+- All schema dataclasses subclass `JsonDataclass` providing `to_dict` and
+  `from_dict` helpers for round-trip serialization.
 - `json_io.py` offers generic helpers for loading and dumping these dataclasses to and from JSON.
+- Runtime dataclasses `shop.py`, `skill.py`, `help.py`, and `social.py`
+  mirror their schema counterparts for use inside the game engine.
 
 Legacy `area.py`, `room.py`, `mob.py`, and `obj.py` structures have been superseded and should not
 be used in new code.

--- a/mud/models/__init__.py
+++ b/mud/models/__init__.py
@@ -1,11 +1,16 @@
 """Data models for QuickMUD translated from C structs."""
 
 from .area import Area
-from .room import Room, ExtraDescr, Exit, Reset
+from .room import Room, ExtraDescr, Exit
+from .room_json import ResetJson as Reset
 from .mob import MobIndex, MobProgram
 from .obj import ObjIndex, ObjectData, Affect
 from .object import Object
 from .character import Character, PCData
+from .shop import Shop
+from .skill import Skill
+from .help import HelpEntry
+from .social import Social
 from .constants import (
     Direction,
     Sector,
@@ -35,6 +40,7 @@ from .shop_json import ShopJson
 from .help_json import HelpJson
 from .social_json import SocialJson
 from .json_io import (
+    JsonDataclass,
     dataclass_from_dict,
     dataclass_to_dict,
     dump_dataclass,
@@ -55,6 +61,10 @@ __all__ = [
     "Affect",
     "Character",
     "PCData",
+    "Shop",
+    "Skill",
+    "HelpEntry",
+    "Social",
     # JSON schema-aligned dataclasses
     "AreaJson",
     "VnumRangeJson",
@@ -73,6 +83,7 @@ __all__ = [
     "ShopJson",
     "HelpJson",
     "SocialJson",
+    "JsonDataclass",
     "dataclass_from_dict",
     "dataclass_to_dict",
     "load_dataclass",

--- a/mud/models/area.py
+++ b/mud/models/area.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from .room_json import ResetJson
+
+
 @dataclass
 class Area:
-    """Python representation of AREA_DATA from merc.h"""
+    """Runtime area container loaded from legacy files."""
     file_name: Optional[str] = None
     name: Optional[str] = None
     credits: Optional[str] = None
@@ -20,7 +23,7 @@ class Area:
     area_flags: int = 0
     security: int = 0
     helps: List[object] = field(default_factory=list)
-    resets: List['Reset'] = field(default_factory=list)
+    resets: List[ResetJson] = field(default_factory=list)
     next: Optional['Area'] = None
 
     def __repr__(self) -> str:

--- a/mud/models/area_json.py
+++ b/mud/models/area_json.py
@@ -6,17 +6,18 @@ from typing import List
 from .room_json import RoomJson
 from .character_json import CharacterJson
 from .object_json import ObjectJson
+from .json_io import JsonDataclass
 
 
 @dataclass
-class VnumRangeJson:
+class VnumRangeJson(JsonDataclass):
     """Minimum and maximum vnums for an area."""
     min: int
     max: int
 
 
 @dataclass
-class AreaJson:
+class AreaJson(JsonDataclass):
     """Area record matching ``schemas/area.schema.json``."""
     name: str
     vnum_range: VnumRangeJson

--- a/mud/models/character.py
+++ b/mud/models/character.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mud.models.object import Object
+    from mud.models.room import Room
     from mud.db.models import Character as DBCharacter
 
 @dataclass
@@ -48,8 +49,10 @@ class Character:
     act: int = 0
     affected_by: int = 0
     position: int = 0
+    room: Optional['Room'] = None
     practice: int = 0
     train: int = 0
+    skills: Dict[str, int] = field(default_factory=dict)
     carry_weight: int = 0
     carry_number: int = 0
     saving_throw: int = 0
@@ -113,6 +116,6 @@ def to_orm(character: Character, player_id: int) -> 'DBCharacter':
         name=character.name,
         level=character.level,
         hp=character.hit,
-        room_vnum=character.room.vnum if getattr(character, "room", None) else None,
+        room_vnum=character.room.vnum if character.room else None,
         player_id=player_id,
     )

--- a/mud/models/character_json.py
+++ b/mud/models/character_json.py
@@ -2,30 +2,33 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
+import builtins
+
+from .json_io import JsonDataclass
 
 
 @dataclass
-class ResourceJson:
+class ResourceJson(JsonDataclass):
     """Track current and maximum resource values."""
     current: int
     max: int
 
 
 @dataclass
-class StatsJson:
+class StatsJson(JsonDataclass):
     """Primary stats and pooled resources."""
     str: int
     int: int
-    wis: int
-    dex: int
-    con: int
+    wis: builtins.int
+    dex: builtins.int
+    con: builtins.int
     hitpoints: ResourceJson
     mana: ResourceJson
     move: ResourceJson
 
 
 @dataclass
-class CharacterJson:
+class CharacterJson(JsonDataclass):
     """Character record matching ``schemas/character.schema.json``."""
     id: int
     name: str

--- a/mud/models/help.py
+++ b/mud/models/help.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .help_json import HelpJson
+
+
+@dataclass
+class HelpEntry:
+    """Runtime representation of a help entry."""
+
+    keywords: list[str]
+    text: str
+    level: int = 0
+
+    @classmethod
+    def from_json(cls, data: HelpJson) -> "HelpEntry":
+        return cls(**data.to_dict())

--- a/mud/models/help_json.py
+++ b/mud/models/help_json.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .json_io import JsonDataclass
+
 
 @dataclass
-class HelpJson:
+class HelpJson(JsonDataclass):
     """Help entry matching ``schemas/help.schema.json``."""
 
     keywords: list[str]

--- a/mud/models/object_json.py
+++ b/mud/models/object_json.py
@@ -3,23 +3,25 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from .json_io import JsonDataclass
+
 
 @dataclass
-class AffectJson:
+class AffectJson(JsonDataclass):
     """Per-object affect modifier."""
     location: str
     modifier: int
 
 
 @dataclass
-class ExtraDescriptionJson:
+class ExtraDescriptionJson(JsonDataclass):
     """Extra description block for objects."""
     keyword: str
     description: str
 
 
 @dataclass
-class ObjectJson:
+class ObjectJson(JsonDataclass):
     """Object record matching ``schemas/object.schema.json``."""
     id: int
     name: str

--- a/mud/models/player_json.py
+++ b/mud/models/player_json.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from .json_io import JsonDataclass
+
 
 @dataclass
-class PlayerJson:
+class PlayerJson(JsonDataclass):
     """Player record matching ``schemas/player.schema.json``."""
 
     name: str

--- a/mud/models/room.py
+++ b/mud/models/room.py
@@ -5,8 +5,11 @@ from typing import List, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from mud.models.object import Object
     from mud.spawning.templates import MobInstance
+    from mud.models.area import Area
+    from mud.models.character import Character
 
 from .constants import Direction
+from .room_json import ResetJson
 
 @dataclass
 class ExtraDescr:
@@ -27,17 +30,8 @@ class Exit:
     orig_door: int = 0
 
 @dataclass
-class Reset:
-    """Representation of RESET_DATA"""
-    command: str
-    arg1: int
-    arg2: int
-    arg3: int
-    arg4: int
-
-@dataclass
 class Room:
-    """Python representation of ROOM_INDEX_DATA"""
+    """Runtime room container built from area files."""
     vnum: int
     name: Optional[str] = None
     description: Optional[str] = None
@@ -51,7 +45,7 @@ class Room:
     clan: int = 0
     exits: List[Optional[Exit]] = field(default_factory=lambda: [None] * len(Direction))
     extra_descr: List[ExtraDescr] = field(default_factory=list)
-    resets: List[Reset] = field(default_factory=list)
+    resets: List[ResetJson] = field(default_factory=list)
     people: List['Character'] = field(default_factory=list)
     contents: List['Object'] = field(default_factory=list)
     next: Optional['Room'] = None

--- a/mud/models/room_json.py
+++ b/mud/models/room_json.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from .json_io import JsonDataclass
+
 
 @dataclass
-class ExitJson:
+class ExitJson(JsonDataclass):
     """Exit specification for JSON rooms."""
     to_room: int
     description: Optional[str] = None
@@ -14,14 +16,14 @@ class ExitJson:
 
 
 @dataclass
-class ExtraDescriptionJson:
+class ExtraDescriptionJson(JsonDataclass):
     """Extra description block for JSON rooms."""
     keyword: str
     description: str
 
 
 @dataclass
-class ResetJson:
+class ResetJson(JsonDataclass):
     """Reset command affecting a room."""
     command: str
     arg1: Optional[int] = None
@@ -31,7 +33,7 @@ class ResetJson:
 
 
 @dataclass
-class RoomJson:
+class RoomJson(JsonDataclass):
     """Room record matching ``schemas/room.schema.json``."""
     id: int
     name: str

--- a/mud/models/shop.py
+++ b/mud/models/shop.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .json_io import JsonDataclass
+from .shop_json import ShopJson
 
 
 @dataclass
-class ShopJson(JsonDataclass):
-    """Shop record matching ``schemas/shop.schema.json``."""
+class Shop:
+    """Runtime representation of a shop."""
 
     keeper: int
     buy_types: list[str] = field(default_factory=list)
@@ -15,3 +15,7 @@ class ShopJson(JsonDataclass):
     profit_sell: int = 100
     open_hour: int = 0
     close_hour: int = 23
+
+    @classmethod
+    def from_json(cls, data: ShopJson) -> "Shop":
+        return cls(**data.to_dict())

--- a/mud/models/skill.py
+++ b/mud/models/skill.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from .skill_json import SkillJson
+
+
+@dataclass
+class Skill:
+    """Runtime representation of a skill or spell."""
+
+    name: str
+    type: str
+    function: str
+    target: str = "victim"
+    mana_cost: int = 0
+    lag: int = 0
+    cooldown: int = 0
+    failure_rate: float = 0.0
+    messages: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, data: SkillJson) -> "Skill":
+        return cls(**data.to_dict())

--- a/mud/models/skill_json.py
+++ b/mud/models/skill_json.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from .json_io import JsonDataclass
+
 
 @dataclass
-class SkillJson:
+class SkillJson(JsonDataclass):
     """Schema-aligned representation of a skill or spell."""
 
     name: str
@@ -13,4 +15,6 @@ class SkillJson:
     target: str = "victim"
     mana_cost: int = 0
     lag: int = 0
+    cooldown: int = 0
+    failure_rate: float = 0.0
     messages: dict[str, str] = field(default_factory=dict)

--- a/mud/models/social.py
+++ b/mud/models/social.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .json_io import JsonDataclass
+from .social_json import SocialJson
 
 
 @dataclass
-class SocialJson(JsonDataclass):
-    """Social command messages matching ``schemas/social.schema.json``."""
+class Social:
+    """Runtime representation of a social command."""
 
     name: str
     char_no_arg: str = ""
@@ -17,3 +17,7 @@ class SocialJson(JsonDataclass):
     vict_found: str = ""
     char_auto: str = ""
     others_auto: str = ""
+
+    @classmethod
+    def from_json(cls, data: SocialJson) -> "Social":
+        return cls(**data.to_dict())

--- a/mud/skills/__init__.py
+++ b/mud/skills/__init__.py
@@ -1,3 +1,3 @@
-from .registry import load_skills, skill_registry
+from .registry import SkillRegistry, load_skills, skill_registry
 
-__all__ = ["load_skills", "skill_registry"]
+__all__ = ["SkillRegistry", "load_skills", "skill_registry"]

--- a/mud/world/world_state.py
+++ b/mud/world/world_state.py
@@ -3,7 +3,7 @@ from mud.loaders import load_all_areas
 from mud.registry import room_registry, area_registry, mob_registry, obj_registry
 from mud.db.session import SessionLocal
 from mud.db import models
-from mud.models.character import Character
+from mud.models.character import Character, character_registry
 from mud.spawning.reset_handler import apply_resets
 from .linking import link_exits
 
@@ -99,4 +99,5 @@ def create_test_character(name: str, room_vnum: int) -> Character:
     char = Character(name=name)
     if room:
         room.add_character(char)
+    character_registry.append(char)
     return char

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -21,3 +21,18 @@
 
 - Convert `#SHOPS` sections with `convert_shops_to_json.py`; map item type numbers to `ItemType` names and skip zeros.
 - Cross-check converted table counts with source files; fail tests on mismatches.
+- Make every schema dataclass subclass `JsonDataclass`; never hand-roll JSON serialization.
+- Stop cloning `merc.h` structs; favor schema dataclasses like `ResetJson` in loaders and handlers.
+- Create runtime dataclasses mirroring each schema; never operate on JSON dataclasses inside the engine.
+- Reset ticks must clear mobs and objects before reapplying area resets.
+- Test reset scheduler with ticks to ensure repop occurs when areas empty.
+- Drive command dispatch through a Command dataclass; match unique prefixes and block admin-only commands in dispatcher.
+- Use shlex.split for argument parsing; reject ambiguous abbreviations as unknown commands.
+- Force hits or misses by cranking hitroll; don't seed global RNG in tests.
+- Flip positions: set both to FIGHTING on swing, set victim DEAD and attacker STANDING when killing.
+- Drive all skill usage through `skill_registry`; never hard-code spell lists.
+- Inject RNG into `SkillRegistry` for deterministic failure tests.
+- Level ups must call `advance_level`; never adjust `level` without stat gains.
+- Practice and train commands must consume sessions and validate targets.
+- Shop prices must use `shop.profit_buy`/`shop.profit_sell`; never charge raw object cost.
+- Write player saves atomically: dump to a temp file and `os.replace`.

--- a/tests/test_advancement.py
+++ b/tests/test_advancement.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
 from mud.advancement import exp_per_level, gain_exp
+from mud.commands.advancement import do_practice, do_train
 from mud.models.character import Character
+from mud.skills.registry import load_skills, skill_registry
 
 def test_gain_exp_levels_character():
     char = Character(level=1, ch_class=0, race=0, exp=0)
@@ -12,3 +16,30 @@ def test_exp_per_level_applies_modifiers():
     human = Character(level=1, ch_class=3, race=0, exp=0)
     elf = Character(level=1, ch_class=3, race=1, exp=0)
     assert exp_per_level(elf) > exp_per_level(human)
+
+
+def test_gain_exp_increases_stats_and_sessions():
+    char = Character(level=1, ch_class=0, race=0, exp=0,
+                     max_hit=20, max_mana=20, max_move=20,
+                     practice=0, train=0)
+    base = exp_per_level(char)
+    char.exp = base
+    gain_exp(char, base)
+    assert char.level == 2
+    assert char.max_hit > 20
+    assert char.practice > 0
+    assert char.train > 0
+
+
+def test_practice_and_train_commands():
+    skill_registry.skills.clear()
+    load_skills(Path("data/skills.json"))
+    char = Character(practice=1, train=1)
+    msg = do_practice(char, "fireball")
+    assert char.practice == 0
+    assert char.skills["fireball"] == 25
+    assert "practice fireball" in msg
+    msg = do_train(char, "hp")
+    assert char.train == 0
+    assert char.max_hit > 0
+    assert "train your hp" in msg

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,5 +1,6 @@
 from mud.world import initialize_world, create_test_character
 from mud.commands import process_command
+from mud.models.constants import Position
 
 
 def setup_combat():
@@ -13,19 +14,37 @@ def setup_combat():
 def test_attack_damages_but_not_kill():
     attacker, victim = setup_combat()
     attacker.damroll = 3
+    attacker.hitroll = 100  # guarantee hit
     victim.hit = 10
     out = process_command(attacker, 'kill victim')
     assert out == 'You hit Victim for 3 damage.'
     assert victim.hit == 7
+    assert attacker.position == Position.FIGHTING
+    assert victim.position == Position.FIGHTING
     assert victim in attacker.room.people
 
 
 def test_attack_kills_target():
     attacker, victim = setup_combat()
     attacker.damroll = 5
+    attacker.hitroll = 100  # guarantee hit
     victim.hit = 5
     out = process_command(attacker, 'kill victim')
     assert out == 'You kill Victim.'
     assert victim.hit == 0
+    assert attacker.position == Position.STANDING
+    assert victim.position == Position.DEAD
     assert victim not in attacker.room.people
     assert 'Victim is DEAD!!!' in attacker.messages
+
+
+def test_attack_misses_target():
+    attacker, victim = setup_combat()
+    attacker.hitroll = -100  # guarantee miss
+    victim.hit = 10
+    out = process_command(attacker, 'kill victim')
+    assert out == 'You miss Victim.'
+    assert victim.hit == 10
+    assert attacker.position == Position.FIGHTING
+    assert victim.position == Position.FIGHTING
+    assert victim in attacker.room.people

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,3 +40,17 @@ def test_equipment_command():
     out = process_command(char, 'equipment')
     assert 'You are using' in out
     assert 'wield' in out
+
+
+def test_abbreviations_and_quotes():
+    initialize_world('area/area.lst')
+    char = create_test_character('Tester', 3001)
+
+    out1 = process_command(char, 'l')
+    assert 'Temple' in out1
+
+    out2 = process_command(char, 'n')
+    assert 'You walk north' in out2
+
+    out3 = process_command(char, 'say "hello world"')
+    assert out3 == "You say, 'hello world'"

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -47,3 +47,38 @@ def test_nested_area_roundtrip():
     out.seek(0)
     dumped = json.load(out)
     assert dumped["rooms"][0]["flags"] == []
+
+
+def test_room_method_roundtrip_defaults():
+    data = {
+        "id": 1,
+        "name": "A room",
+        "description": "desc",
+        "sector_type": "inside",
+        "area": 0,
+    }
+    room = RoomJson.from_dict(data)
+    assert room.flags == []
+    dumped = room.to_dict()
+    assert dumped["flags"] == []
+    assert dumped["exits"] == {}
+
+
+def test_area_method_roundtrip():
+    area_data = {
+        "name": "Test",
+        "vnum_range": {"min": 0, "max": 10},
+        "rooms": [
+            {
+                "id": 1,
+                "name": "r1",
+                "description": "d1",
+                "sector_type": "inside",
+                "area": 0,
+            }
+        ],
+    }
+    area = AreaJson.from_dict(area_data)
+    assert area.rooms[0].flags == []
+    dumped = area.to_dict()
+    assert dumped["rooms"][0]["flags"] == []

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,10 +1,12 @@
 from mud.world import initialize_world, create_test_character
 from mud.spawning.obj_spawner import spawn_object
+from mud.models.character import character_registry
 import mud.persistence as persistence
 
 
 def test_character_json_persistence(tmp_path):
     persistence.PLAYERS_DIR = tmp_path
+    character_registry.clear()
     initialize_world('area/area.lst')
     char = create_test_character('Saver', 3001)
     sword = spawn_object(3022)
@@ -20,3 +22,29 @@ def test_character_json_persistence(tmp_path):
     assert loaded.room.vnum == 3001
     assert any(obj.prototype.vnum == 3022 for obj in loaded.inventory)
     assert loaded.equipment['head'].prototype.vnum == 3356
+
+
+def test_save_is_atomic(tmp_path):
+    persistence.PLAYERS_DIR = tmp_path
+    character_registry.clear()
+    initialize_world('area/area.lst')
+    char = create_test_character('Atomic', 3001)
+    # create corrupt existing file
+    (tmp_path / 'atomic.json').write_text('garbage')
+    persistence.save_character(char)
+    loaded = persistence.load_character('Atomic')
+    assert loaded is not None
+
+
+def test_save_and_load_world(tmp_path):
+    persistence.PLAYERS_DIR = tmp_path
+    character_registry.clear()
+    initialize_world('area/area.lst')
+    create_test_character('One', 3001)
+    create_test_character('Two', 3001)
+    persistence.save_world()
+    character_registry.clear()
+    loaded = persistence.load_world()
+    names = {c.name for c in loaded}
+    assert names == {'One', 'Two'}
+    assert all(c.room.vnum == 3001 for c in loaded)

--- a/tests/test_runtime_models.py
+++ b/tests/test_runtime_models.py
@@ -1,0 +1,40 @@
+from mud.models import (
+    ShopJson,
+    Shop,
+    SkillJson,
+    Skill,
+    HelpJson,
+    HelpEntry,
+    SocialJson,
+    Social,
+)
+
+
+def test_shop_from_json():
+    data = ShopJson(keeper=123, buy_types=["weapon"], profit_buy=110)
+    shop = Shop.from_json(data)
+    assert shop.keeper == 123
+    assert shop.buy_types == ["weapon"]
+    assert shop.profit_buy == 110
+
+
+def test_skill_from_json():
+    data = SkillJson(name="fireball", type="spell", function="do_fireball")
+    skill = Skill.from_json(data)
+    assert skill.name == "fireball"
+    assert skill.function == "do_fireball"
+
+
+def test_help_from_json():
+    data = HelpJson(keywords=["foo"], text="bar", level=1)
+    help_entry = HelpEntry.from_json(data)
+    assert help_entry.keywords == ["foo"]
+    assert help_entry.text == "bar"
+    assert help_entry.level == 1
+
+
+def test_social_from_json():
+    data = SocialJson(name="smile", char_no_arg="You smile.")
+    social = Social.from_json(data)
+    assert social.name == "smile"
+    assert social.char_no_arg == "You smile."

--- a/tests/test_shops.py
+++ b/tests/test_shops.py
@@ -1,6 +1,7 @@
 from mud.world import initialize_world, create_test_character
 from mud.commands.dispatcher import process_command
 from mud.registry import shop_registry
+from mud.spawning.obj_spawner import spawn_object
 
 
 def test_buy_from_grocer():
@@ -10,8 +11,27 @@ def test_buy_from_grocer():
     char.gold = 100
     list_output = process_command(char, 'list')
     assert 'hooded brass lantern' in list_output
-    assert '40 gold' in list_output
+    assert '60 gold' in list_output
     buy_output = process_command(char, 'buy lantern')
     assert 'buy a hooded brass lantern' in buy_output.lower()
-    assert char.gold == 60
+    assert char.gold == 40
     assert any((obj.short_descr or '').lower().startswith('a hooded brass lantern') for obj in char.inventory)
+
+
+def test_sell_to_grocer():
+    initialize_world('area/area.lst')
+    char = create_test_character('Seller', 3010)
+    char.gold = 0
+    lantern = spawn_object(3031)
+    assert lantern is not None
+    lantern.prototype.item_type = 1
+    char.add_object(lantern)
+    sell_output = process_command(char, 'sell lantern')
+    assert 'sell a hooded brass lantern' in sell_output.lower()
+    assert char.gold == 16
+    keeper = next(
+        p for p in char.room.people if getattr(p, 'prototype', None) and p.prototype.vnum in shop_registry
+    )
+    assert any(
+        (obj.short_descr or '').lower().startswith('a hooded brass lantern') for obj in keeper.inventory
+    )

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -4,8 +4,9 @@ from mud.skills import load_skills, skill_registry
 
 
 def test_load_skills_registers_handlers():
-    skill_registry.clear()
+    skill_registry.skills.clear()
+    skill_registry.handlers.clear()
     skills_path = Path(__file__).resolve().parent.parent / "data" / "skills.json"
     load_skills(skills_path)
-    assert "fireball" in skill_registry
-    assert skill_registry["fireball"](None, None) == 42
+    assert "fireball" in skill_registry.skills
+    assert skill_registry.handlers["fireball"](None, None) == 42

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from random import Random
+
+import pytest
+
+from mud.models.character import Character
+from mud.skills import SkillRegistry
+
+
+def load_registry() -> SkillRegistry:
+    reg = SkillRegistry(rng=Random(0))
+    reg.load(Path("data/skills.json"))
+    return reg
+
+
+def test_cast_fireball_success() -> None:
+    reg = load_registry()
+    caster = Character(mana=20)
+    target = Character()
+
+    result = reg.use(caster, "fireball", target)
+    assert result == 42
+    assert caster.mana == 10
+    assert caster.cooldowns["fireball"] == 2
+
+    with pytest.raises(ValueError):
+        reg.use(caster, "fireball", target)
+
+    reg.tick(caster)
+    reg.tick(caster)
+    reg.use(caster, "fireball", target)
+    assert caster.mana == 0
+
+
+def test_cast_fireball_failure() -> None:
+    reg = load_registry()
+    skill = reg.get("fireball")
+    skill.failure_rate = 1.0
+
+    called: list[bool] = []
+
+    def dummy(caster, target):  # pragma: no cover - test helper
+        called.append(True)
+        return 99
+
+    reg.handlers["fireball"] = dummy
+
+    caster = Character(mana=20)
+    target = Character()
+    result = reg.use(caster, "fireball", target)
+    assert result is False
+    assert caster.mana == 10
+    assert called == []

--- a/tests/test_spawning.py
+++ b/tests/test_spawning.py
@@ -1,11 +1,32 @@
 from mud.world import initialize_world
-from mud.registry import room_registry
+from mud.registry import room_registry, area_registry, mob_registry, obj_registry
+from mud.spawning.reset_handler import reset_tick, RESET_TICKS
 
 
 def test_resets_populate_world():
+    room_registry.clear()
+    area_registry.clear()
+    mob_registry.clear()
+    obj_registry.clear()
     initialize_world('area/area.lst')
     bakery = room_registry[3001]
     assert any(getattr(m, 'name', None) for m in bakery.people)
 
     donation = room_registry[3054]
+    assert any(getattr(o, 'short_descr', None) == 'the donation pit' for o in donation.contents)
+
+
+def test_resets_repop_after_tick():
+    room_registry.clear()
+    area_registry.clear()
+    mob_registry.clear()
+    obj_registry.clear()
+    initialize_world('area/area.lst')
+    bakery = room_registry[3001]
+    donation = room_registry[3054]
+    bakery.people.clear()
+    donation.contents.clear()
+    for _ in range(RESET_TICKS):
+        reset_tick()
+    assert any(getattr(m, 'name', None) for m in bakery.people)
     assert any(getattr(o, 'short_descr', None) == 'the donation pit' for o in donation.contents)


### PR DESCRIPTION
## Summary
- write player saves atomically and register characters when loading
- expose world save/load via character registry and document persistence
- mark port-plan persistence milestone complete and record instructions

## Testing
- `ruff check mud/persistence.py mud/world/world_state.py tests/test_persistence.py`
- `mypy mud/persistence.py mud/world/world_state.py tests/test_persistence.py --follow-imports=skip`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b9f94a650c83208a980821f56907ed