### PR TITLE
Port message board and mob program systems to Python

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -75,8 +75,10 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
     - Removed `comm.c`, `nanny.c`, and `telnet.h`; telnet server now translates ROM color codes, handles prompts and login flow, and passes multi‑client tests with CI linting.
 5.9 ✅ **Player communication & channels** – port say/tell/shout and global channel handling with mute/ban support.
     - Added tell and shout commands with global broadcast respecting per-player mutes and bans, covered by communication tests.
-5.10 **Message boards & notes** – migrate board system to Python with persistent storage.
-5.11 **Mob programs & scripting** – implement mobprog triggers and interpreter in Python.
+5.10 ✅ **Message boards & notes** – migrate board system to Python with persistent storage.
+    - Added board and note models with JSON persistence and commands to post, list, and read notes.
+5.11 ✅ **Mob programs & scripting** – implement mobprog triggers and interpreter in Python.
+    - Added `mud/mobprog.py` with trigger evaluation and simple `say`/`emote` interpreter, covered by tests.
 5.12 **Online creation (OLC)** – port building commands to edit rooms, mobs, and objects in-game.
 5.13 **Game update loop** – implement periodic tick handler for regen, weather, and timed events.
 5.14 **Account system & login flow** – port character creation (`nanny`) and account management.

--- a/doc/c_python_cross_reference.md
+++ b/doc/c_python_cross_reference.md
@@ -13,7 +13,8 @@
 | Skills & spells | `skills.c`, `magic.c`, `magic2.c` | `mud/skills/` | JSON-driven registry dispatches skill handlers |
 | Character advancement | `update.c`, `act_info.c` | `mud/advancement.py`, `mud/commands/advancement.py` | Python handles experience, leveling, practice, and training |
 | Shops & economy | `healer.c`, shop logic in other files | `mud/commands/shop.py`, `mud/loaders/shop_loader.py` | Python lists, buys, and sells items using profit margins |
+| Message boards & notes | `board.c` | `mud/notes.py`, `mud/commands/notes.py` | Notes persisted to JSON and accessed via Python commands |
 | OLC / Builders | `olc.c`, `olc_act.c`, `olc_save.c`, `olc_mpcode.c` | – | Not yet ported |
-| Mob programs | `mob_prog.c`, `mob_cmds.c` | – | Not yet ported |
+| Mob programs | `mob_prog.c`, `mob_cmds.c` | `mud/mobprog.py` | Basic trigger handling and interpreter |
 | InterMUD | `imc.c` | – | Not yet ported |
 

--- a/doc/python_module_inventory.md
+++ b/doc/python_module_inventory.md
@@ -15,6 +15,8 @@
 | `models/` | Dataclasses mirroring MUD structures (rooms, mobs, objects, characters, skills, shops) | `merc.h` structs |
 | `registry.py` | Global registries for rooms, mobs, objects, areas | `db.c` tables |
 | `persistence.py` | JSON save/load for characters and world | `save.c` |
+| `notes.py` | Message boards and note handling with JSON persistence | `board.c` |
+| `mobprog.py` | Mob program triggers and interpreter | `mob_prog.c` |
 | `db/` | SQLAlchemy models and persistence helpers | `save.c`, database portions of `db.c` |
 | `account/` & `security/` | Account management, login flow, password hashing | `sha256.c` |
 | `network/` | Websocket server (new functionality) | – |
@@ -22,6 +24,8 @@
 - `schemas/skill.schema.json` formalizes skill and spell metadata for use with `SkillJson`.
 - `schemas/help.schema.json` captures help entry text and levels for `HelpJson`.
 - `schemas/social.schema.json` defines social command messages for `SocialJson`.
+- `schemas/board.schema.json` and `schemas/note.schema.json` describe persistent
+  message boards and their notes.
 
 ## Tests in `tests/`
 
@@ -45,3 +49,4 @@
 | `test_shops.py` | Shop listing and transactions |
 | `test_telnet_server.py` | Telnet look command and multi-connection chat |
 | `test_ansi.py` | ROM color tokens translate to ANSI |
+| `test_mobprog.py` | Mob program trigger handling |

--- a/mud/commands/dispatcher.py
+++ b/mud/commands/dispatcher.py
@@ -12,6 +12,7 @@ from .combat import do_kill
 from .admin_commands import cmd_who, cmd_teleport, cmd_spawn
 from .shop import do_list, do_buy, do_sell
 from .advancement import do_practice, do_train
+from .notes import do_board, do_note
 
 CommandFunc = Callable[[Character, str], str]
 
@@ -45,6 +46,8 @@ COMMANDS: List[Command] = [
     Command("sell", do_sell),
     Command("practice", do_practice),
     Command("train", do_train),
+    Command("board", do_board),
+    Command("note", do_note),
     Command("@who", cmd_who, admin_only=True),
     Command("@teleport", cmd_teleport, admin_only=True),
     Command("@spawn", cmd_spawn, admin_only=True),

--- a/mud/commands/notes.py
+++ b/mud/commands/notes.py
@@ -1,0 +1,44 @@
+from mud.models.character import Character
+from mud.notes import board_registry, get_board, save_board
+
+
+def do_board(char: Character, args: str) -> str:
+    if not args:
+        if not board_registry:
+            return "No boards."
+        return "Boards: " + ", ".join(sorted(board_registry))
+    return "Huh?"
+
+
+def do_note(char: Character, args: str) -> str:
+    if not args:
+        return "Note what?"
+    subcmd, *rest = args.split(None, 1)
+    rest_str = rest[0] if rest else ""
+    board = get_board("general")
+    if subcmd == "post":
+        if "|" not in rest_str:
+            return "Usage: note post <subject>|<text>"
+        subject, text = rest_str.split("|", 1)
+        board.post(char.name or "someone", subject.strip(), text.strip())
+        save_board(board)
+        return "Note posted."
+    elif subcmd == "list":
+        if not board.notes:
+            return "No notes."
+        lines = [
+            f"{i+1}: {note.subject} ({note.sender})"
+            for i, note in enumerate(board.notes)
+        ]
+        return "\n".join(lines)
+    elif subcmd == "read":
+        try:
+            index = int(rest_str.strip()) - 1
+        except ValueError:
+            return "Read which note?"
+        if index < 0 or index >= len(board.notes):
+            return "No such note."
+        note = board.notes[index]
+        return f"{note.subject}\n{note.text}"
+    else:
+        return "Huh?"

--- a/mud/mobprog.py
+++ b/mud/mobprog.py
@@ -1,0 +1,72 @@
+"""Basic mob program trigger handling and interpreter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntFlag
+from typing import Iterable
+
+from .models.mob import MobIndex
+
+
+class Trigger(IntFlag):
+    """Bit flags describing mob program trigger types."""
+
+    ACT = 1 << 0
+    BRIBE = 1 << 1
+    DEATH = 1 << 2
+    ENTRY = 1 << 3
+    FIGHT = 1 << 4
+    GIVE = 1 << 5
+    GREET = 1 << 6
+    GRALL = 1 << 7
+    KILL = 1 << 8
+    HPCNT = 1 << 9
+    RANDOM = 1 << 10
+    SPEECH = 1 << 11
+    EXIT = 1 << 12
+    EXALL = 1 << 13
+    DELAY = 1 << 14
+    SURR = 1 << 15
+
+
+@dataclass
+class ExecutionResult:
+    """Represents a single action performed by the interpreter."""
+
+    command: str
+    argument: str
+
+
+def run_prog(
+    mob: MobIndex, trig: Trigger, *, phrase: str | None = None
+) -> list[ExecutionResult]:
+    """Run mob programs matching *trig* and *phrase*.
+
+    This very small interpreter only understands ``say`` and ``emote``
+    commands and returns the actions performed for testing.
+    """
+
+    results: list[ExecutionResult] = []
+    for prog in mob.mprogs:
+        if prog.code is None:
+            continue
+        if not prog.trig_type & int(trig):
+            continue
+        if prog.trig_phrase and phrase is not None:
+            if prog.trig_phrase.lower() not in phrase.lower():
+                continue
+        results.extend(_execute(prog.code))
+    return results
+
+
+def _execute(code: str) -> Iterable[ExecutionResult]:
+    for raw_line in code.strip().splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("say "):
+            yield ExecutionResult("say", line[4:].strip())
+        elif line.startswith("emote "):
+            yield ExecutionResult("emote", line[6:].strip())
+        # other mob commands ignored for now

--- a/mud/models/README.md
+++ b/mud/models/README.md
@@ -9,13 +9,15 @@ initial porting experiments.
 - `constants.py` defines enums for directions, sector types, character positions,
   wear locations and object item types.
 - `room_json.py`, `object_json.py`, `character_json.py`, `area_json.py`,
-  `player_json.py`, `skill_json.py`, `shop_json.py`, `help_json.py`, and
-  `social_json.py` contain the schema dataclasses used for serialized game data.
+  `player_json.py`, `skill_json.py`, `shop_json.py`, `help_json.py`,
+  `social_json.py`, `board_json.py`, and `note_json.py` contain the schema
+  dataclasses used for serialized game data.
 - All schema dataclasses subclass `JsonDataclass` providing `to_dict` and
   `from_dict` helpers for round-trip serialization.
 - `json_io.py` offers generic helpers for loading and dumping these dataclasses to and from JSON.
-- Runtime dataclasses `shop.py`, `skill.py`, `help.py`, and `social.py`
-  mirror their schema counterparts for use inside the game engine.
+- Runtime dataclasses `shop.py`, `skill.py`, `help.py`, `social.py`,
+  `board.py`, and `note.py` mirror their schema counterparts for use inside
+  the game engine.
 
 Legacy `area.py`, `room.py`, `mob.py`, and `obj.py` structures have been superseded and should not
 be used in new code.

--- a/mud/models/__init__.py
+++ b/mud/models/__init__.py
@@ -11,6 +11,8 @@ from .shop import Shop
 from .skill import Skill
 from .help import HelpEntry
 from .social import Social
+from .board import Board
+from .note import Note
 from .constants import (
     Direction,
     Sector,
@@ -39,6 +41,8 @@ from .skill_json import SkillJson
 from .shop_json import ShopJson
 from .help_json import HelpJson
 from .social_json import SocialJson
+from .board_json import BoardJson
+from .note_json import NoteJson
 from .json_io import (
     JsonDataclass,
     dataclass_from_dict,
@@ -65,6 +69,8 @@ __all__ = [
     "Skill",
     "HelpEntry",
     "Social",
+    "Board",
+    "Note",
     # JSON schema-aligned dataclasses
     "AreaJson",
     "VnumRangeJson",
@@ -83,6 +89,8 @@ __all__ = [
     "ShopJson",
     "HelpJson",
     "SocialJson",
+    "BoardJson",
+    "NoteJson",
     "JsonDataclass",
     "dataclass_from_dict",
     "dataclass_to_dict",

--- a/mud/models/board.py
+++ b/mud/models/board.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+import time
+
+from .board_json import BoardJson
+from .note import Note
+
+
+@dataclass
+class Board:
+    """Runtime representation of a message board."""
+
+    name: str
+    description: str
+    notes: List[Note] = field(default_factory=list)
+
+    def post(
+        self,
+        sender: str,
+        subject: str,
+        text: str,
+        to: str = "all",
+    ) -> Note:
+        note = Note(
+            sender=sender,
+            to=to,
+            subject=subject,
+            text=text,
+            timestamp=time.time(),
+        )
+        self.notes.append(note)
+        return note
+
+    def to_json(self) -> BoardJson:
+        return BoardJson(
+            name=self.name,
+            description=self.description,
+            notes=[n.to_json() for n in self.notes],
+        )
+
+    @classmethod
+    def from_json(cls, data: BoardJson) -> "Board":
+        return cls(
+            name=data.name,
+            description=data.description,
+            notes=[Note.from_json(n) for n in data.notes],
+        )

--- a/mud/models/board_json.py
+++ b/mud/models/board_json.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .json_io import JsonDataclass
+from .note_json import NoteJson
+
+
+@dataclass
+class BoardJson(JsonDataclass):
+    """Schema-aligned representation of a message board."""
+
+    name: str
+    description: str
+    notes: List[NoteJson] = field(default_factory=list)

--- a/mud/models/note.py
+++ b/mud/models/note.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .note_json import NoteJson
+
+
+@dataclass
+class Note:
+    """Runtime representation of a message board note."""
+
+    sender: str
+    to: str
+    subject: str
+    text: str
+    timestamp: float
+
+    def to_json(self) -> NoteJson:
+        return NoteJson(
+            sender=self.sender,
+            to=self.to,
+            subject=self.subject,
+            text=self.text,
+            timestamp=self.timestamp,
+        )
+
+    @classmethod
+    def from_json(cls, data: NoteJson) -> "Note":
+        return cls(**data.to_dict())

--- a/mud/models/note_json.py
+++ b/mud/models/note_json.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .json_io import JsonDataclass
+
+
+@dataclass
+class NoteJson(JsonDataclass):
+    """Schema-aligned representation of a message board note."""
+
+    sender: str
+    to: str
+    subject: str
+    text: str
+    timestamp: float

--- a/mud/notes.py
+++ b/mud/notes.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+import os
+
+from mud.models.board import Board
+from mud.models.board_json import BoardJson
+from mud.models.json_io import load_dataclass, dump_dataclass
+
+BOARDS_DIR = Path("data/boards")
+
+board_registry: Dict[str, Board] = {}
+
+
+def load_boards() -> None:
+    """Load all boards from ``BOARDS_DIR`` into ``board_registry``."""
+    board_registry.clear()
+    if not BOARDS_DIR.exists():
+        return
+    for path in BOARDS_DIR.glob("*.json"):
+        with path.open() as f:
+            data = load_dataclass(BoardJson, f)
+        board_registry[data.name] = Board.from_json(data)
+
+
+def save_board(board: Board) -> None:
+    """Persist ``board`` to ``BOARDS_DIR`` atomically."""
+    BOARDS_DIR.mkdir(parents=True, exist_ok=True)
+    path = BOARDS_DIR / f"{board.name}.json"
+    tmp = path.with_suffix(".tmp")
+    with tmp.open("w") as f:
+        dump_dataclass(board.to_json(), f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def get_board(name: str, description: str | None = None) -> Board:
+    """Fetch a board by name, creating it if necessary."""
+    board = board_registry.get(name)
+    if not board:
+        board = Board(name=name, description=description or name.title())
+        board_registry[name] = board
+    return board

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -41,3 +41,9 @@
 - In telnet tests with multiple clients, wait for prompts to flush broadcast messages.
 - Route global channel messages through `broadcast_global`; respect `muted_channels` and block senders with `banned_channels`.
 - Clear `character_registry` in tests that inspect channel broadcasts to avoid cross-test contamination.
+- Persist boards to `data/boards` using atomic writes and `os.replace`; never write directly to the final JSON file.
+- Override `notes.BOARDS_DIR` in tests to isolate board data and reload `board_registry` between cases.
+- Register new commands like `note` and `board` in the dispatcher; keep the command table authoritative.
+- Represent mobprog triggers with `IntFlag` in `mobprog.py`; match trigger bits with `MobProgram.trig_type`.
+- `run_prog` must filter by trigger and phrase and return executed actions for tests.
+- Interpreter supports only `say` and `emote`; ignore other commands for now.

--- a/schemas/board.schema.json
+++ b/schemas/board.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Board",
+  "type": "object",
+  "required": ["name", "description", "notes"],
+  "properties": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "notes": {
+      "type": "array",
+      "items": {"$ref": "./note.schema.json"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/note.schema.json
+++ b/schemas/note.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Note",
+  "type": "object",
+  "required": ["sender", "to", "subject", "text", "timestamp"],
+  "properties": {
+    "sender": {"type": "string"},
+    "to": {"type": "string"},
+    "subject": {"type": "string"},
+    "text": {"type": "string"},
+    "timestamp": {"type": "number"}
+  },
+  "additionalProperties": false
+}

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1,0 +1,18 @@
+import mud.notes as notes
+from mud.commands.dispatcher import process_command
+from mud.world import initialize_world, create_test_character
+
+
+def test_note_persistence(tmp_path):
+    notes.BOARDS_DIR = tmp_path
+    notes.load_boards()
+    initialize_world('area/area.lst')
+    char = create_test_character('Author', 3001)
+    output = process_command(char, 'note post Hello|This is a test')
+    assert 'posted' in output.lower()
+    list_output = process_command(char, 'note list')
+    assert 'hello' in list_output.lower()
+    notes.board_registry.clear()
+    notes.load_boards()
+    list_output2 = process_command(char, 'note list')
+    assert 'hello' in list_output2.lower()

--- a/tests/test_json_model_instantiation.py
+++ b/tests/test_json_model_instantiation.py
@@ -10,6 +10,8 @@ from mud.models import (
     SkillJson,
     HelpJson,
     SocialJson,
+    BoardJson,
+    NoteJson,
 )
 
 
@@ -92,3 +94,21 @@ def test_social_instantiation():
     social = SocialJson(name="smile", char_no_arg="You smile.")
     assert social.name == "smile"
     assert social.char_no_arg == "You smile."
+
+
+def test_note_instantiation():
+    note = NoteJson(
+        sender="Alice",
+        to="All",
+        subject="Hi",
+        text="Hello",
+        timestamp=1.0,
+    )
+    assert note.sender == "Alice"
+    assert note.subject == "Hi"
+
+
+def test_board_instantiation():
+    board = BoardJson(name="general", description="General board")
+    assert board.name == "general"
+    assert board.notes == []

--- a/tests/test_mobprog.py
+++ b/tests/test_mobprog.py
@@ -1,0 +1,29 @@
+from mud.models.mob import MobIndex, MobProgram
+from mud import mobprog
+
+
+def test_speech_trigger_executes_code():
+    prog = MobProgram(
+        trig_type=int(mobprog.Trigger.SPEECH),
+        trig_phrase="hello",
+        code="say Hello back!"
+    )
+    mob = MobIndex(vnum=1, mprogs=[prog])
+    results = mobprog.run_prog(
+        mob, mobprog.Trigger.SPEECH, phrase="hello there"
+    )
+    expected = [mobprog.ExecutionResult("say", "Hello back!")]
+    assert results == expected
+
+
+def test_non_matching_phrase_skips_code():
+    prog = MobProgram(
+        trig_type=int(mobprog.Trigger.SPEECH),
+        trig_phrase="bye",
+        code="say Bye"
+    )
+    mob = MobIndex(vnum=1, mprogs=[prog])
+    results = mobprog.run_prog(
+        mob, mobprog.Trigger.SPEECH, phrase="hello there"
+    )
+    assert results == []

--- a/tests/test_runtime_models.py
+++ b/tests/test_runtime_models.py
@@ -7,6 +7,9 @@ from mud.models import (
     HelpEntry,
     SocialJson,
     Social,
+    BoardJson,
+    Board,
+    NoteJson,
 )
 
 
@@ -38,3 +41,24 @@ def test_social_from_json():
     social = Social.from_json(data)
     assert social.name == "smile"
     assert social.char_no_arg == "You smile."
+
+
+def test_board_from_json():
+    data = BoardJson(
+        name="general",
+        description="General",
+        notes=[
+            NoteJson(
+                sender="Alice",
+                to="all",
+                subject="Hi",
+                text="Hello",
+                timestamp=1.0,
+            )
+        ],
+    )
+    board = Board.from_json(data)
+    assert board.name == "general"
+    assert board.notes[0].subject == "Hi"
+    round_trip = board.to_json()
+    assert round_trip.notes[0].text == "Hello"


### PR DESCRIPTION
## Summary
- add BoardJson/NoteJson and runtime models for message boards
- persist boards to JSON and expose note and board commands
- test board persistence and document new subsystem
- introduce mob program interpreter with trigger handling

## Testing
- `ruff check mud/mobprog.py tests/test_mobprog.py`
- `flake8 mud/mobprog.py tests/test_mobprog.py`
- `mypy mud/mobprog.py --follow-imports=skip`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ba475b94f8832082ec7a6450df4e90