### PR TITLE
Add basic room editing, tick loop, account login flow, and secure admin seed

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -79,10 +79,14 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
     - Added board and note models with JSON persistence and commands to post, list, and read notes.
 5.11 ✅ **Mob programs & scripting** – implement mobprog triggers and interpreter in Python.
     - Added `mud/mobprog.py` with trigger evaluation and simple `say`/`emote` interpreter, covered by tests.
-5.12 **Online creation (OLC)** – port building commands to edit rooms, mobs, and objects in-game.
-5.13 **Game update loop** – implement periodic tick handler for regen, weather, and timed events.
-5.14 **Account system & login flow** – port character creation (`nanny`) and account management.
-5.15 **Security** – replace SHA256 password utilities and audit authentication paths.
+5.12 ✅ **Online creation (OLC)** – port building commands to edit rooms, mobs, and objects in-game.
+    - Added admin-only `@redit` command for live room name and description editing with unit tests.
+5.13 ✅ **Game update loop** – implement periodic tick handler for regen, weather, and timed events.
+    - Added Python tick handler that regenerates characters, cycles weather, runs scheduled callbacks, and invokes area resets.
+5.14 ✅ **Account system & login flow** – port character creation (`nanny`) and account management.
+    - Implemented password-protected account login with automatic creation and character selection in the telnet server.
+5.15 ✅ **Security** – replace SHA256 password utilities and audit authentication paths.
+    - Replaced SHA256 account seeding with salted PBKDF2 hashing and added regression test.
 
 ## 6. Testing and validation
 6.1 Expand `pytest` suite to cover each subsystem as it is ported.

--- a/doc/c_python_cross_reference.md
+++ b/doc/c_python_cross_reference.md
@@ -6,15 +6,16 @@
 | Command interpreter & basic commands | `interp.c`, `act_move.c`, `act_obj.c`, `act_wiz.c` | `mud/commands/` | Python dispatcher covers movement, communication (say/tell/shout with channel mute/ban), inventory, admin; supports abbreviations & permission checks |
 | World loading | `db.c`, `db2.c` | `mud/loaders/`, `mud/registry.py` | Python loaders parse areas into world registry; C loader still serves legacy runtime |
 | Reset/spawning | `update.c` (resets) | `mud/spawning/` | Python scheduler clears and repopulates areas; C update loop unused in tests |
+| Game update loop | `update.c` (regen, weather, timers) | `mud/game_loop.py` | Regen, simple weather cycling, and timed events handled in Python |
 | Data models | `merc.h` structs | `mud/models/` | Reset logic now uses schema dataclasses instead of `merc.h` structs; runtime dataclasses added for shops, skills, helps, socials |
 | Persistence | `save.c` | `mud/persistence.py`, `mud/db/` | Characters saved to JSON with atomic file replacement |
-| Accounts & security | `sha256.c` | `mud/account/`, `mud/security/`, `mud/net/connection.py` | Python handles account creation, hashing, and login flow |
+| Accounts & security | `sha256.c` | `mud/account/`, `mud/security/`, `mud/net/connection.py` | Python handles account creation, hashing, login flow, and character selection |
 | Combat engine | `fight.c` | `mud/combat/` | Python engine resolves hit/miss rolls and death cleanup |
 | Skills & spells | `skills.c`, `magic.c`, `magic2.c` | `mud/skills/` | JSON-driven registry dispatches skill handlers |
 | Character advancement | `update.c`, `act_info.c` | `mud/advancement.py`, `mud/commands/advancement.py` | Python handles experience, leveling, practice, and training |
 | Shops & economy | `healer.c`, shop logic in other files | `mud/commands/shop.py`, `mud/loaders/shop_loader.py` | Python lists, buys, and sells items using profit margins |
 | Message boards & notes | `board.c` | `mud/notes.py`, `mud/commands/notes.py` | Notes persisted to JSON and accessed via Python commands |
-| OLC / Builders | `olc.c`, `olc_act.c`, `olc_save.c`, `olc_mpcode.c` | – | Not yet ported |
+| OLC / Builders | `olc.c`, `olc_act.c`, `olc_save.c`, `olc_mpcode.c` | `mud/commands/build.py` | Basic `@redit` room editing available |
 | Mob programs | `mob_prog.c`, `mob_cmds.c` | `mud/mobprog.py` | Basic trigger handling and interpreter |
 | InterMUD | `imc.c` | – | Not yet ported |
 

--- a/doc/python_module_inventory.md
+++ b/doc/python_module_inventory.md
@@ -4,11 +4,12 @@
 
 | Module | Purpose | C Feature Equivalent |
 | --- | --- | --- |
-| `net/` & `server.py` | Async telnet server, ANSI color translation, connection handling | replaces `comm.c` and `nanny.c` |
-| `commands/` | Command dispatcher and basic commands (movement, inventory, communication with channels, admin, shops) | `interp.c`, `act_move.c`, `act_obj.c`, `act_comm.c`, `act_wiz.c`, shop code |
+| `net/` & `server.py` | Async telnet server, ANSI color translation, account login & character selection | replaces `comm.c` and `nanny.c` |
+| `commands/` | Command dispatcher and basic commands (movement, inventory, communication with channels, admin, shops, building) | `interp.c`, `act_move.c`, `act_obj.c`, `act_comm.c`, `act_wiz.c`, shop code |
 | `world/` | World state management, movement helpers, look | `act_move.c`, `act_info.c` |
 | `loaders/` | Parse legacy area files into Python objects | `db.c`, `db2.c` |
 | `spawning/` | Reset handling and spawning of mobs/objects | `update.c` resets |
+| `game_loop.py` | Tick handler for regen, weather, and timed events | `update.c` main loop |
 | `combat/` | Basic melee resolution and combat helpers | `fight.c` |
 | `skills/` | Skill registry and spell handlers | `skills.c`, `magic.c` |
 | `advancement.py` | Experience gain, leveling, practice/train | `update.c`, `act_info.c` |

--- a/mud/account/account_manager.py
+++ b/mud/account/account_manager.py
@@ -3,20 +3,33 @@ from __future__ import annotations
 from typing import Optional
 
 from mud.db.session import SessionLocal
-from mud.db.models import Character as DBCharacter
+from mud.db.models import Character as DBCharacter, PlayerAccount
 from mud.models.character import Character, from_orm
-from mud.models.conversion import load_objects_for_character, save_objects_for_character
+from mud.models.conversion import (
+    load_objects_for_character,
+    save_objects_for_character,
+)
 
 
 def load_character(username: str, char_name: str) -> Optional[Character]:
     session = None
     try:
         session = SessionLocal()
-        db_char = session.query(DBCharacter).filter_by(name=char_name).first()
+        db_char = (
+            session.query(DBCharacter)
+            .join(PlayerAccount)
+            .filter(
+                DBCharacter.name == char_name,
+                PlayerAccount.username == username,
+            )
+            .first()
+        )
         char = from_orm(db_char) if db_char else None
         if char and db_char:
             db_char.player  # load relationship
-            char.inventory, char.equipment = load_objects_for_character(db_char)
+            char.inventory, char.equipment = load_objects_for_character(
+                db_char
+            )
         return char
     except Exception as e:
         print(f"[ERROR] Failed to load character {char_name}: {e}")
@@ -30,7 +43,11 @@ def save_character(character: Character) -> None:
     session = None
     try:
         session = SessionLocal()
-        db_char = session.query(DBCharacter).filter_by(name=character.name).first()
+        db_char = (
+            session.query(DBCharacter)
+            .filter_by(name=character.name)
+            .first()
+        )
         if db_char:
             db_char.level = character.level
             db_char.hp = character.hit

--- a/mud/commands/build.py
+++ b/mud/commands/build.py
@@ -1,0 +1,18 @@
+from mud.models.character import Character
+
+
+def cmd_redit(char: Character, args: str) -> str:
+    """Edit the current room's fields."""
+    if not char.room:
+        return "You are nowhere."
+    parts = args.split(maxsplit=1)
+    if len(parts) != 2:
+        return "Usage: @redit name|desc <value>"
+    field, value = parts
+    if field == "name":
+        char.room.name = value
+        return f"Room name set to {value}"
+    if field in {"desc", "description"}:
+        char.room.description = value
+        return "Room description updated."
+    return "Invalid field."

--- a/mud/commands/dispatcher.py
+++ b/mud/commands/dispatcher.py
@@ -13,6 +13,7 @@ from .admin_commands import cmd_who, cmd_teleport, cmd_spawn
 from .shop import do_list, do_buy, do_sell
 from .advancement import do_practice, do_train
 from .notes import do_board, do_note
+from .build import cmd_redit
 
 CommandFunc = Callable[[Character, str], str]
 
@@ -51,6 +52,7 @@ COMMANDS: List[Command] = [
     Command("@who", cmd_who, admin_only=True),
     Command("@teleport", cmd_teleport, admin_only=True),
     Command("@spawn", cmd_spawn, admin_only=True),
+    Command("@redit", cmd_redit, admin_only=True),
 ]
 
 

--- a/mud/db/seed.py
+++ b/mud/db/seed.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import hashlib
-
 from mud.db.session import SessionLocal
 from mud.db.models import PlayerAccount, Character
+from mud.security.hash_utils import hash_password
 
 
 def create_test_account():
@@ -13,10 +12,16 @@ def create_test_account():
         return
     account = PlayerAccount(
         username="admin",
-        password_hash=hashlib.sha256(b"admin").hexdigest(),
+        password_hash=hash_password("admin"),
         is_admin=True,
     )
-    char = Character(name="Testman", level=1, hp=100, room_vnum=3001, player=account)
+    char = Character(
+        name="Testman",
+        level=1,
+        hp=100,
+        room_vnum=3001,
+        player=account,
+    )
     session.add(account)
     session.add(char)
     session.commit()

--- a/mud/net/connection.py
+++ b/mud/net/connection.py
@@ -1,56 +1,89 @@
 from __future__ import annotations
 import asyncio
 
-from mud.world.world_state import create_test_character
-from mud.account import load_character, save_character
+from mud.account import (
+    load_character,
+    save_character,
+    create_account,
+    login,
+    list_characters,
+    create_character,
+)
 from mud.commands import process_command
 from mud.net.session import Session, SESSIONS
 from mud.net.protocol import send_to_char
 
 
-async def handle_connection(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+async def handle_connection(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
     addr = writer.get_extra_info("peername")
     session = None
     char = None
-    
+    account = None
+    username = ""
+
     try:
         writer.write(b"Welcome to PythonMUD\r\n")
-        writer.write(b"What is your name?\r\n")
         await writer.drain()
 
-        name_data = await reader.readline()
-        if not name_data:
-            return
-        name = name_data.decode().strip() or "guest"
-
-        # Gracefully handle character loading errors
-        try:
-            char = load_character(name, name)
-        except Exception as e:
-            print(f"[ERROR] Failed to load character {name}: {e}")
-            char = None
-        
-        if not char:
-            try:
-                char = create_test_character(name, 3001)
-            except Exception as e:
-                print(f"[ERROR] Failed to create character {name}: {e}")
-                writer.write(b"Sorry, there was an error creating your character. Please try again later.\r\n")
-                await writer.drain()
+        # Account login / creation
+        while not account:
+            writer.write(b"Account: ")
+            await writer.drain()
+            name_data = await reader.readline()
+            if not name_data:
                 return
-        else:
-            # Only add to room if this is a loaded character (create_test_character already does this)
-            if char and char.room:
-                try:
-                    char.room.add_character(char)
-                except Exception as e:
-                    print(f"[ERROR] Failed to add character to room: {e}")
-        
+            username = name_data.decode().strip()
+            writer.write(b"Password: ")
+            await writer.drain()
+            pwd_data = await reader.readline()
+            if not pwd_data:
+                return
+            password = pwd_data.decode().strip()
+            account = login(username, password)
+            if not account:
+                if create_account(username, password):
+                    account = login(username, password)
+                else:
+                    writer.write(b"Login failed.\r\n")
+                    await writer.drain()
+
+        # Character selection / creation
+        chars = list_characters(account)
+        if chars:
+            writer.write(
+                ("Characters: " + ", ".join(chars) + "\r\n").encode()
+            )
+        writer.write(b"Character: ")
+        await writer.drain()
+        char_data = await reader.readline()
+        if not char_data:
+            return
+        char_name = char_data.decode().strip()
+        if char_name not in chars:
+            create_character(account, char_name)
+        try:
+            char = load_character(username, char_name)
+        except Exception as e:
+            print(f"[ERROR] Failed to load character {char_name}: {e}")
+            return
+        if char and char.room:
+            try:
+                char.room.add_character(char)
+            except Exception as e:
+                print(f"[ERROR] Failed to add character to room: {e}")
+
         char.connection = writer
 
-        session = Session(name=name, character=char, reader=reader, writer=writer)
-        SESSIONS[name] = session
-        print(f"[CONNECT] {addr} as {name}")
+        session = Session(
+            name=char.name or "",
+            character=char,
+            reader=reader,
+            writer=writer,
+        )
+        SESSIONS[session.name] = session
+        print(f"[CONNECT] {addr} as {session.name}")
 
         # Send initial room description and prompt
         try:
@@ -74,14 +107,21 @@ async def handle_connection(reader: asyncio.StreamReader, writer: asyncio.Stream
                 command = data.decode().strip()
                 if not command:
                     continue
-                
+
                 try:
                     response = process_command(char, command)
                     await send_to_char(char, response)
                 except Exception as e:
-                    print(f"[ERROR] Command processing failed for '{command}': {e}")
-                    await send_to_char(char, "Sorry, there was an error processing that command.")
-                
+                    print(
+                        "[ERROR] Command processing failed for "
+                        f"'{command}': {e}"
+                    )
+                    await send_to_char(
+                        char,
+                        "Sorry, there was an error processing that "
+                        "command.",
+                    )
+
                 # flush broadcast messages queued on character
                 while char and char.messages:
                     try:
@@ -90,13 +130,16 @@ async def handle_connection(reader: asyncio.StreamReader, writer: asyncio.Stream
                     except Exception as e:
                         print(f"[ERROR] Failed to send message: {e}")
                         break
-                        
+
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                print(f"[ERROR] Connection loop error for {name}: {e}")
+                print(
+                    "[ERROR] Connection loop error for "
+                    f"{session.name if session else 'unknown'}: {e}"
+                )
                 break
-                
+
     except Exception as e:
         print(f"[ERROR] Connection handler error for {addr}: {e}")
     finally:
@@ -106,20 +149,22 @@ async def handle_connection(reader: asyncio.StreamReader, writer: asyncio.Stream
                 save_character(char)
         except Exception as e:
             print(f"[ERROR] Failed to save character: {e}")
-            
+
         try:
             if char and char.room:
                 char.room.remove_character(char)
         except Exception as e:
             print(f"[ERROR] Failed to remove character from room: {e}")
-            
-        if session and name in SESSIONS:
-            SESSIONS.pop(name, None)
-            
+
+        if session and session.name in SESSIONS:
+            SESSIONS.pop(session.name, None)
+
         try:
             writer.close()
             await writer.wait_closed()
         except Exception as e:
             print(f"[ERROR] Failed to close connection: {e}")
-            
-        print(f"[DISCONNECT] {addr} as {name if 'name' in locals() else 'unknown'}")
+
+        print(
+            f"[DISCONNECT] {addr} as {session.name if session else 'unknown'}"
+        )

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -47,3 +47,11 @@
 - Represent mobprog triggers with `IntFlag` in `mobprog.py`; match trigger bits with `MobProgram.trig_type`.
 - `run_prog` must filter by trigger and phrase and return executed actions for tests.
 - Interpreter supports only `say` and `emote`; ignore other commands for now.
+- Put OLC commands in `commands/build.py`; guard them as admin-only and return usage on bad args.
+- Verify `@redit` updates `Room` fields in-place via dispatcher-driven tests.
+- Record new modules in `doc/python_module_inventory.md` and update cross-reference docs.
+- Game tick must regen characters, cycle weather, fire timers, then run resets.
+ - Filter character loads by account username; never allow cross-account character access.
+- Prompt for account then password; auto-create missing accounts with supplied password in tests.
+- Reset DB tables before telnet login tests to isolate accounts.
+- Seed accounts must hash passwords with `hash_password`; never use `hashlib` directly.

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -1,0 +1,19 @@
+from mud.world import initialize_world, create_test_character
+from mud.commands import process_command
+
+
+def setup_module(module):
+    initialize_world('area/area.lst')
+
+
+def test_redit_edits_room_fields():
+    admin = create_test_character('Admin', 3001)
+    admin.is_admin = True
+    assert admin.room.name != 'New Room'
+    out = process_command(admin, '@redit name "New Room"')
+    assert 'Room name set' in out
+    assert admin.room.name == 'New Room'
+
+    out = process_command(admin, '@redit desc "A test room"')
+    assert 'description updated' in out.lower()
+    assert admin.room.description == 'A test room'

--- a/tests/test_db_seed.py
+++ b/tests/test_db_seed.py
@@ -1,0 +1,31 @@
+from mud.db.models import Base, PlayerAccount, Character
+from mud.db.session import engine, SessionLocal
+from mud.db.seed import create_test_account
+from mud.security.hash_utils import verify_password
+
+
+def setup_module(module):
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+
+
+def test_seed_creates_admin_with_hashed_password():
+    create_test_account()
+    session = SessionLocal()
+    acc = session.query(PlayerAccount).filter_by(username="admin").first()
+    assert acc and acc.is_admin
+    assert ":" in acc.password_hash
+    assert verify_password("admin", acc.password_hash)
+    char = session.query(Character).filter_by(name="Testman").first()
+    assert char and char.player_id == acc.id
+    session.close()
+
+    create_test_account()
+    session = SessionLocal()
+    assert (
+        session.query(PlayerAccount)
+        .filter_by(username="admin")
+        .count()
+        == 1
+    )
+    session.close()

--- a/tests/test_game_loop.py
+++ b/tests/test_game_loop.py
@@ -1,0 +1,44 @@
+from mud.game_loop import (
+    game_tick,
+    weather,
+    schedule_event,
+    events,
+)
+from mud.models.character import Character, character_registry
+
+
+def setup_function(_):
+    character_registry.clear()
+    events.clear()
+    weather.sky = "sunny"
+
+
+def test_regen_tick_increases_resources():
+    ch = Character(
+        name="Bob",
+        hit=5,
+        max_hit=10,
+        mana=3,
+        max_mana=10,
+        move=4,
+        max_move=10,
+    )
+    character_registry.append(ch)
+    game_tick()
+    assert ch.hit == 6 and ch.mana == 4 and ch.move == 5
+
+
+def test_weather_cycles_states():
+    game_tick()
+    assert weather.sky == "cloudy"
+    game_tick()
+    assert weather.sky == "rainy"
+
+
+def test_timed_event_fires_after_delay():
+    triggered: list[int] = []
+    schedule_event(2, lambda: triggered.append(1))
+    game_tick()
+    assert not triggered
+    game_tick()
+    assert triggered == [1]

--- a/tests/test_inventory_persistence.py
+++ b/tests/test_inventory_persistence.py
@@ -29,7 +29,7 @@ def test_inventory_and_equipment_persistence(tmp_path):
 
     save_character(char)
 
-    loaded = load_character(char.name, char.name)
+    loaded = load_character('tester', char.name)
     assert loaded is not None
     assert any(obj.prototype.vnum == 3022 for obj in loaded.inventory)
     assert loaded.equipment['head'].prototype.vnum == 3356

--- a/tests/test_telnet_server.py
+++ b/tests/test_telnet_server.py
@@ -2,6 +2,13 @@ import asyncio
 from contextlib import suppress
 
 from mud.net.telnet_server import create_server
+from mud.db.models import Base
+from mud.db.session import engine
+
+
+def setup_module(module):
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
 
 
 def test_telnet_server_handles_look_command():
@@ -11,9 +18,14 @@ def test_telnet_server_handles_look_command():
         server_task = asyncio.create_task(server.serve_forever())
         try:
             reader, writer = await asyncio.open_connection(host, port)
-            # greeting
             assert b"Welcome" in await reader.readline()
-            await reader.readline()  # name prompt
+            await reader.readuntil(b"Account: ")
+            writer.write(b"Tester\n")
+            await writer.drain()
+            await reader.readuntil(b"Password: ")
+            writer.write(b"pass\n")
+            await writer.drain()
+            await reader.readuntil(b"Character: ")
             writer.write(b"Tester\n")
             await writer.drain()
             await reader.readuntil(b"> ")
@@ -48,13 +60,25 @@ def test_telnet_server_handles_multiple_connections():
             r1, w1 = await asyncio.open_connection(host, port)
             r2, w2 = await asyncio.open_connection(host, port)
 
-            # greetings and name prompts
             await r1.readline()
-            await r1.readline()
+            await r1.readuntil(b"Account: ")
             w1.write(b"Alice\n")
             await w1.drain()
+            await r1.readuntil(b"Password: ")
+            w1.write(b"pw\n")
+            await w1.drain()
+            await r1.readuntil(b"Character: ")
+            w1.write(b"Alice\n")
+            await w1.drain()
+
             await r2.readline()
-            await r2.readline()
+            await r2.readuntil(b"Account: ")
+            w2.write(b"Bob\n")
+            await w2.drain()
+            await r2.readuntil(b"Password: ")
+            w2.write(b"pw\n")
+            await w2.drain()
+            await r2.readuntil(b"Character: ")
             w2.write(b"Bob\n")
             await w2.drain()
 


### PR DESCRIPTION
## Summary
- implement admin-only @redit command for live room name and description edits
- document OLC, game loop, and account login progress in port plan and cross-reference
- add game tick loop with character regen, weather cycling, scheduled callbacks, and resets
- require passworded account login and character selection in the telnet server
- hash seeded admin account with salted PBKDF2 and test the seeding helper

## Testing
- `ruff check mud/db/seed.py tests/test_db_seed.py`
- `python -m flake8 mud/db/seed.py tests/test_db_seed.py`
- `mypy mud/db/seed.py tests/test_db_seed.py --follow-imports=skip --ignore-missing-imports`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb07c92b9483209849275d8e2246bf