### PR TITLE
Add FastAPI-based runtime dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 SQLAlchemy>=2.0,<3
+Typer>=0.9
+python-dotenv>=1.0
+fastapi
+uvicorn

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(
         "SQLAlchemy>=2.0",
         "typer>=0.9",
         "python-dotenv>=1.0",
+        "fastapi",
+        "uvicorn",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary
- include Typer, python-dotenv, FastAPI, and Uvicorn in runtime dependencies
- mirror dependencies in `setup.py` install_requires

## Testing
- `pip install -e .[dev]`
- `pytest`
- `python -m venv /tmp/venvtest && source /tmp/venvtest/bin/activate && pip install . && mud --help`


------
https://chatgpt.com/codex/tasks/task_b_68bb63e5a2f88320986112e6b501d2dd