### PR TITLE
Align SQLAlchemy dependency range

### DIFF
--- a/mud/pyproject.toml
+++ b/mud/pyproject.toml
@@ -7,7 +7,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
-sqlalchemy = ">=2.0"
+sqlalchemy = ">=2.0,<3"
 typer = ">=0.9"
 python-dotenv = ">=1.0"
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=['mud'] + [f'mud.{p}' for p in find_packages('mud')],
     package_dir={'mud': 'mud'},
     install_requires=[
-        "SQLAlchemy>=2.0",
+        "SQLAlchemy>=2.0,<3",
         "typer>=0.9",
         "python-dotenv>=1.0",
         "fastapi",


### PR DESCRIPTION
## Summary
- Harmonize the SQLAlchemy version specifier across dependency files
- Ensure consistent build tooling for SQLAlchemy 2.x

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb694c71648320add6760b9a2317e9