### PR TITLE
Document installation steps and add build metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ pytest_cache/
 tests/__pycache__/
 game.db
 .history/
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,51 @@ The legacy C engine has been fully replaced by a pure Python 3 codebase.
 All game logic now lives in the `mud/` package and game data is loaded
 from JSON files under `data/`.
 
+## Installation
+
+### Users
+
+```bash
+pip install quickmud
+```
+
+Run the server with:
+
+```bash
+mud runserver
+```
+
+### Developers
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -e .[dev]
+# or for a reproducible environment
+pip install -r requirements-dev.txt
+```
+
+Run tests with:
+
+```bash
+pytest
+```
+
+## Building and publishing
+
+Build a wheel and source distribution:
+
+```bash
+python -m build
+```
+
+Upload the artifacts to PyPI:
+
+```bash
+twine upload dist/*
+```
+
+
 ## Python Architecture
 
 Game systems are implemented in Python modules:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,9 @@
 -r requirements.txt
-pytest>=8.3
-pytest-cov>=6.0
-mypy
-ruff
-flake8
-jsonschema
+pytest==8.4.2
+pytest-cov==6.2.1
+mypy==1.17.1
+ruff==0.12.11
+flake8==7.3.0
+jsonschema==4.25.1
+build==1.3.0
+twine==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-SQLAlchemy>=2.0,<3
-Typer>=0.9
-python-dotenv>=1.0
-fastapi
-uvicorn
+SQLAlchemy==2.0.43
+Typer==0.17.4
+python-dotenv==1.1.1
+fastapi==0.116.1
+uvicorn==0.35.0


### PR DESCRIPTION
## Summary
- pin runtime and development dependencies for reproducible installs
- document wheel building and publishing in README
- ignore build artifacts and add dev tools for release

## Testing
- `python -m build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bb6bd1d4b88320b2f4072f61ba78d2